### PR TITLE
#190 - Don't lint vendor files

### DIFF
--- a/library/.sass-lint.yml
+++ b/library/.sass-lint.yml
@@ -5,6 +5,7 @@ files:
     - 'components/legacy/**/*.scss'
     - 'styles/legacy_styles/**/*.scss'
     - 'styles/case_studies.scss'
+    - 'styles/vendor/**/*.scss'
 options:
   formatter: stylish
   merge-default-rules: false


### PR DESCRIPTION
Quick fix to remove the sass-lint errors on vendor style files, specifically the Bootstrap files.