### PR TITLE
Feature/223  cdn asset changes

### DIFF
--- a/doc-site/components/tint_stack/tint_stack.scss
+++ b/doc-site/components/tint_stack/tint_stack.scss
@@ -56,7 +56,7 @@ $esds-doc-tint-stack-space-swatch-inset: $spirit-space-inset-3-x;
 
 .es-contrast-grid {
   box-sizing: border-box;
-  font-family: $font-family-sans-serif;
+  font-family: $spirit-font-family-sans-serif;
   overflow: auto;
   width: 100%;
 }

--- a/doc-site/esds-build-config.js
+++ b/doc-site/esds-build-config.js
@@ -24,6 +24,7 @@ module.exports = {
             name: 'spirit-styles',
             sources: [
                     'node_modules/@jdrfhq/spirit/dist/spirit.css',
+                    'node_modules/@jdrfhq/spirit/dist/spirit.min.css',
                     'node_modules/prismjs/themes/prism.css'], // required by esds-doc
             destination: '../docs/styles/dependencies',
             watch: true

--- a/doc-site/esds-build-config.js
+++ b/doc-site/esds-build-config.js
@@ -26,7 +26,7 @@ module.exports = {
                     'node_modules/@jdrfhq/spirit/dist/spirit.css',
                     'node_modules/@jdrfhq/spirit/dist/spirit.min.css',
                     'node_modules/prismjs/themes/prism.css'], // required by esds-doc
-            destination: '../docs/styles/dependencies',
+            destination: '../docs/styles',
             watch: true
         },
         {

--- a/doc-site/styles/spirit_doc_site.scss
+++ b/doc-site/styles/spirit_doc_site.scss
@@ -1,4 +1,9 @@
-@import '../node_modules/@jdrfhq/spirit/styles/spirit';
+// @import '../node_modules/@jdrfhq/spirit/styles/spirit';
+@import '../node_modules/@jdrfhq/spirit/tokens/tokens';
+@import '../node_modules/@jdrfhq/spirit/styles/mixins/accessibility';
+@import '../node_modules/@jdrfhq/spirit/styles/mixins/box-sizing';
+@import '../node_modules/@jdrfhq/spirit/styles/mixins/color';
+@import '../node_modules/@jdrfhq/spirit/styles/mixins/typography';
 @import 'shared/typography';
 @import 'doc_components/esds_doc_component_overrides';
 

--- a/doc-site/templates/base.njk
+++ b/doc-site/templates/base.njk
@@ -12,7 +12,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {% block head_content_prepend %}{% endblock head_content_prepend %}
         <link rel="stylesheet" href="/styles/dependencies/prism.css">
-        <link rel="stylesheet" href="/styles/dependencies/spirit.css">
+        <link rel="stylesheet" href="/styles/dependencies/spirit.min.css">
         <link rel="stylesheet" href="/styles/spirit_doc_site.css">
         <link rel="shortcut icon" href="">
         {# <script src="/scripts/[your-main-script].js"></script> #}

--- a/doc-site/templates/base.njk
+++ b/doc-site/templates/base.njk
@@ -11,8 +11,8 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {% block head_content_prepend %}{% endblock head_content_prepend %}
-        <link rel="stylesheet" href="/styles/dependencies/prism.css">
-        <link rel="stylesheet" href="/styles/dependencies/spirit.min.css">
+        <link rel="stylesheet" href="/styles/prism.css">
+        <link rel="stylesheet" href="/styles/spirit.min.css">
         <link rel="stylesheet" href="/styles/spirit_doc_site.css">
         <link rel="shortcut icon" href="">
         {# <script src="/scripts/[your-main-script].js"></script> #}

--- a/library/gulpfile.js
+++ b/library/gulpfile.js
@@ -1,6 +1,7 @@
 const gulp = require('esds-build');
 const babel = require('gulp-babel');
-const rename = require("gulp-rename");
+const rename = require('gulp-rename');
+const cleanCSS = require('gulp-clean-css');
 
 gulp.task('compile-script-to-es5', () =>
   gulp.src('_site/latest/scripts/spirit.js')
@@ -9,4 +10,13 @@ gulp.task('compile-script-to-es5', () =>
     .pipe(gulp.dest('_site/latest/scripts'))
 );
 
-gulp.task('esds-hook:post:scripts:build:spirit', gulp.series('compile-script-to-es5'));
+gulp.task('esds-hook:post:scripts:build:all', gulp.series('compile-script-to-es5'));
+
+gulp.task('minify-styles', () =>
+  gulp.src('_site/latest/styles/spirit.css')
+    .pipe(cleanCSS())
+    .pipe(rename('spirit.min.css'))
+    .pipe(gulp.dest('_site/latest/styles'))
+);
+
+gulp.task('esds-hook:post:styles:build:all', gulp.series('minify-styles'));

--- a/library/package-lock.json
+++ b/library/package-lock.json
@@ -1573,6 +1573,23 @@
         }
       }
     },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4472,6 +4489,38 @@
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
           "dev": true
+        }
+      }
+    },
+    "gulp-clean-css": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.10.0.tgz",
+      "integrity": "sha512-7Isf9Y690o/Q5MVjEylH1H7L8WeZ89woW7DnhD5unTintOdZb67KdOayRgp9trUFo+f9UyJtuatV42e/+kghPg==",
+      "dev": true,
+      "requires": {
+        "clean-css": "4.2.1",
+        "plugin-error": "1.0.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
         }
       }
     },

--- a/library/package.json
+++ b/library/package.json
@@ -15,6 +15,7 @@
     "babel-preset-env": "^1.7.0",
     "esds-build": "^0.38.0",
     "gulp-babel": "^7.0.1",
+    "gulp-clean-css": "^3.10.0",
     "gulp-rename": "^1.3.0"
   },
   "dependencies": {

--- a/library/styles/base/fonts.scss
+++ b/library/styles/base/fonts.scss
@@ -1,18 +1,19 @@
+$spirit-font-path: '../fonts/' !default; 
 // Graphik Fonts
 
 // sass-lint:disable-all
 
 @font-face {
   font-family: 'Graphik Web Subset';
-  src: url("../fonts/Graphik-Regular-Web-subset.woff2") format("woff2"), url("../fonts/Graphik-Regular-Web-subset.zopfli.woff") format("woff"), url("../fonts/Graphik-Regular-Web-subset.woff") format("truetype");
+  src: url("#{$spirit-font-path}Graphik-Regular-Web-subset.woff2") format("woff2"), url("#{$spirit-font-path}Graphik-Regular-Web-subset.zopfli.woff") format("woff"), url("#{$spirit-font-path}Graphik-Regular-Web-subset.woff") format("truetype");
   unicode-range: U+21-7E;
 }
 
 // Regular
 @font-face {
   font-family: 'Graphik Web';
-  src: url('../fonts/Graphik-Regular-Web.woff2') format('woff2'),
-  url('../fonts/Graphik-Regular-Web.woff') format('woff');
+  src: url('#{$spirit-font-path}Graphik-Regular-Web.woff2') format('woff2'),
+  url('#{$spirit-font-path}Graphik-Regular-Web.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-stretch: normal;
@@ -22,8 +23,8 @@
 // Medium
 @font-face {
   font-family: 'Graphik Web';
-  src: url('../fonts/Graphik-Medium-Web.woff2') format('woff2'),
-       url('../fonts/Graphik-Medium-Web.woff') format('woff');
+  src: url('#{$spirit-font-path}Graphik-Medium-Web.woff2') format('woff2'),
+       url('#{$spirit-font-path}Graphik-Medium-Web.woff') format('woff');
   font-weight:  500;
   font-style:   normal;
   font-stretch: normal;
@@ -33,8 +34,8 @@
 // Semibold
 @font-face {
   font-family: 'Graphik Web';
-  src: url('../fonts/Graphik-Semibold-Web.woff2') format('woff2'),
-  url('../fonts/Graphik-Semibold-Web.woff') format('woff');
+  src: url('#{$spirit-font-path}Graphik-Semibold-Web.woff2') format('woff2'),
+  url('#{$spirit-font-path}Graphik-Semibold-Web.woff') format('woff');
   font-weight: 600;
   font-style: normal;
   font-stretch: normal;
@@ -44,8 +45,8 @@
 // Bold
 @font-face {
   font-family: 'Graphik Web';
-  src: url('../fonts/Graphik-Bold-Web.woff2') format('woff2'),
-  url('../fonts/Graphik-Bold-Web.woff') format('woff');
+  src: url('#{$spirit-font-path}Graphik-Bold-Web.woff2') format('woff2'),
+  url('#{$spirit-font-path}Graphik-Bold-Web.woff') format('woff');
   font-weight: 700;
   font-style: normal;
   font-stretch: normal;

--- a/library/templates/base.njk
+++ b/library/templates/base.njk
@@ -9,7 +9,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {% block head_content_prepend %}{% endblock head_content_prepend %}
         <link rel="shortcut icon" href="#" />
-        <link rel="stylesheet" href="/styles/spirit.css">
+        <link rel="stylesheet" href="/styles/spirit.min.css">
         <script src="/scripts/dependencies/svg4everybody.min.js"></script>
         <script>
             svg4everybody(); // Enable icons for IE11


### PR DESCRIPTION
You'll need to `npm install` in `library` before running `gulp` in order to build the minified version of the stylesheet.
I also updated some of the build config for `doc-site` so the fonts will reside at the correct path for CDN consumers.