### PR TITLE
Add CSS properties to support icons in IE11

### DIFF
--- a/library/components/icon/icon.scss
+++ b/library/components/icon/icon.scss
@@ -5,6 +5,9 @@
   height: 1em;
   line-height: 1em;
   stroke: currentColor;
+  stroke-linecap: round; // Set inline on the SVGs but stripped by the polyfill we use for IE11
+  stroke-linejoin: round; // Set inline on the SVGs but stripped by the polyfill we use for IE11
+  stroke-width: 2px; // Set inline on the SVGs but stripped by the polyfill we use for IE11
   vertical-align: middle;
   width: 1em;
 }


### PR DESCRIPTION
## Working in IE11 Now
Note the dots on exclamation points and question marks.
![screen shot 2018-08-24 at 4 16 44 pm](https://user-images.githubusercontent.com/979463/44608417-426c9200-a7b9-11e8-8b96-035c59fd1df1.png)

Added some CSS properties that are inlined in our sprite. Since IE11 relies on a polyfill that injects the SVG content inline, those inline properties were getting stripped out. Fortunately they're targetable via CSS. 