### PR TITLE
Feature/19  typography swatch

### DIFF
--- a/doc-site/components/typography_swatch/typography_swatch.njk
+++ b/doc-site/components/typography_swatch/typography_swatch.njk
@@ -1,0 +1,63 @@
+{% macro typography_swatch(
+    alphabet_sample_text=false,
+    sample_text="You Can Help Turn Type One Into Type None",
+    sample_text_styles=false,
+    secondary_sample_text=false,
+    secondary_sample_text_styles=false,
+    sample_text_class=""
+  ) %}
+  {% if sample_text_styles == false and sample_text_class == "" %}
+    {% set sample_text_class = "spirit-h1" %}
+  {% endif %}
+
+  {% if sample_text_styles %}
+    {% set random_number = range(0, 100000) | random %}
+    {% set random_class = 'spirit-doc-typography-swatch--' + random_number %}
+    {% set sample_text_class = sample_text_class + ' ' + random_class %}
+    <style>
+      .{{ random_class }} {
+        {{ sample_text_styles }}
+      }
+    </style>
+  {% endif %}
+
+  {% if secondary_sample_text_styles %}
+    {% set random_number = range(0, 100000) | random %}
+    {% set secondary_random_class = 'spirit-doc-typography-swatch--' + random_number %}
+    {% set secondary_sample_text_class = secondary_random_class %}
+    <style>
+      .{{ secondary_random_class }} {
+        {{ secondary_sample_text_styles }}
+      }
+    </style>
+  {% endif %}
+
+  {% if alphabet_sample_text %}
+    {% set sample_text = typography_swatch_alphabet() %}
+  {% endif %}
+
+  <div class="spirit-doc-typography-swatch">
+    <div class="spirit-doc-typography-swatch__sample_text">
+      {% if sample_text_class %}
+        <span class="{{ sample_text_class }}">
+      {% endif %}
+          <span class="spirit-doc-typography-swatch__sample-text-primary">
+            {{ sample_text | safe }}
+          </span>
+          {% if secondary_sample_text %}
+            <span class="spirit-doc-typography-swatch__sample-text-secondary{{ ' ' + secondary_sample_text_class if secondary_sample_text_class }}">
+              {{ secondary_sample_text | safe }}
+            </span>
+          {% endif %}
+      {% if sample_text_class %}
+        </span>
+      {% endif %}
+    </div>
+  </div>
+{% endmacro %}
+
+{% macro typography_swatch_alphabet() %}
+  ABCDEFGHIJKLMNOPQRSTUVWXYZ<br/>
+  abcdefghijklmnopqrstuvwxyz<br/>
+  1234567890
+{% endmacro %}

--- a/doc-site/components/typography_swatch/typography_swatch.njk
+++ b/doc-site/components/typography_swatch/typography_swatch.njk
@@ -1,10 +1,13 @@
 {% macro typography_swatch(
     alphabet_sample_text=false,
-    sample_text="You Can Help Turn Type One Into Type None",
+    sample_text="You Can Help Turn Type<br/>One Into Type None",
     sample_text_styles=false,
     secondary_sample_text=false,
     secondary_sample_text_styles=false,
-    sample_text_class=""
+    sample_text_class="",
+    title="Heading 1",
+    code_sample=".spirit-h1<br/>@include spirit-h1;",
+    design_specs="font-size: 56px;<br/>font-weight: bold;<br/>line-height: 72px;"
   ) %}
   {% if sample_text_styles == false and sample_text_class == "" %}
     {% set sample_text_class = "spirit-h1" %}
@@ -36,20 +39,32 @@
     {% set sample_text = typography_swatch_alphabet() %}
   {% endif %}
 
-  <div class="spirit-doc-typography-swatch">
-    <div class="spirit-doc-typography-swatch__sample_text">
-      {% if sample_text_class %}
-        <span class="{{ sample_text_class }}">
-      {% endif %}
-          <span class="spirit-doc-typography-swatch__sample-text-primary">
-            {{ sample_text | safe }}
+  {% if design_specs == false %}
+    {% set modifier_class = "spirit-doc-typography-swatch--no-design-specs" %}
+  {% endif %}
+
+  <div class="spirit-doc-typography-swatch{{ ' ' + modifier_class if modifier_class }}">
+    <div class="spirit-doc-typography-swatch__sample-text{{ ' ' + sample_text_class if sample_text_class }}">
+        <span class="spirit-doc-typography-swatch__sample-text-primary{{ ' ' + sample_text_class if sample_text_class }}">
+          {{ sample_text | safe }}
+        </span>
+        {% if secondary_sample_text %}
+          <span class="spirit-doc-typography-swatch__sample-text-secondary{{ ' ' + secondary_sample_text_class if secondary_sample_text_class }}">
+            {{ secondary_sample_text | safe }}
           </span>
-          {% if secondary_sample_text %}
-            <span class="spirit-doc-typography-swatch__sample-text-secondary{{ ' ' + secondary_sample_text_class if secondary_sample_text_class }}">
-              {{ secondary_sample_text | safe }}
-            </span>
-          {% endif %}
-      {% if sample_text_class %}
+        {% endif %}
+    </div>
+    <div class="spirit-doc-typography-swatch__metadata">
+      <span class="spirit-doc-typography-swatch__title-wrap">
+        <span class="spirit-doc-typography-swatch__title">
+          {{ title }}
+        </span></span>
+      <span class="spirit-doc-typography-swatch__code-sample">{{ code_sample | safe }}</span>
+      {% if design_specs %}
+        <span class="spirit-doc-typography-swatch__design-specs-wrap">
+          <span class="spirit-doc-typography-swatch__design-specs">
+            {{ design_specs | safe }}
+          </span>
         </span>
       {% endif %}
     </div>

--- a/doc-site/components/typography_swatch/typography_swatch.njk
+++ b/doc-site/components/typography_swatch/typography_swatch.njk
@@ -7,7 +7,9 @@
     sample_text_class="",
     title="Heading 1",
     code_sample=".spirit-h1<br/>@include spirit-h1;",
-    design_specs="font-size: 56px;<br/>font-weight: bold;<br/>line-height: 72px;"
+    design_specs="font-size: 56px;<br/>font-weight: bold;<br/>line-height: 72px;",
+    highlighted_top_margin=false,
+    highlighted_bottom_margin=false
   ) %}
   {% if sample_text_styles == false and sample_text_class == "" %}
     {% set sample_text_class = "spirit-h1" %}
@@ -39,14 +41,33 @@
     {% set sample_text = typography_swatch_alphabet() %}
   {% endif %}
 
+  {% set modifier_class = "" %}
   {% if design_specs == false %}
-    {% set modifier_class = "spirit-doc-typography-swatch--no-design-specs" %}
+    {% set modifier_class = modifier_class + " spirit-doc-typography-swatch--no-design-specs" %}
+  {% endif %}
+
+  {% if highlighted_top_margin or highlighted_bottom_margin %}
+    {% set modifier_class = modifier_class + " spirit-doc-typography-swatch--space-highlighted" %}
+    {% set inline_sample_text_styles = "style='" %}
+    {% if highlighted_top_margin %}
+      {% set inline_sample_text_styles = inline_sample_text_styles + 'margin-top: ' + highlighted_top_margin + '; ' %}
+    {% endif %}
+    {% if highlighted_bottom_margin %}
+      {% set inline_sample_text_styles = inline_sample_text_styles + 'margin-bottom: ' + highlighted_bottom_margin + '; ' %}
+    {% endif %}
+    {% set inline_sample_text_styles = inline_sample_text_styles + "'" %}
   {% endif %}
 
   <div class="spirit-doc-typography-swatch{{ ' ' + modifier_class if modifier_class }}">
     <div class="spirit-doc-typography-swatch__sample-text{{ ' ' + sample_text_class if sample_text_class }}">
-        <span class="spirit-doc-typography-swatch__sample-text-primary{{ ' ' + sample_text_class if sample_text_class }}">
+        <span class="spirit-doc-typography-swatch__sample-text-primary{{ ' ' + sample_text_class if sample_text_class }}" {{ inline_sample_text_styles | safe if inline_sample_text_styles }}>
+          {% if highlighted_top_margin %}
+            <span style="height: {{ highlighted_top_margin }}" class="spirit-doc-typography-swatch__highlight-space spirit-doc-typography-swatch__highlight-space--top"></span>
+          {% endif %}
           {{ sample_text | safe }}
+          {% if highlighted_bottom_margin %}
+            <span style="height: {{ highlighted_bottom_margin }}" class="spirit-doc-typography-swatch__highlight-space spirit-doc-typography-swatch__highlight-space--bottom"></span>
+          {% endif %}
         </span>
         {% if secondary_sample_text %}
           <span class="spirit-doc-typography-swatch__sample-text-secondary{{ ' ' + secondary_sample_text_class if secondary_sample_text_class }}">

--- a/doc-site/components/typography_swatch/typography_swatch.scss
+++ b/doc-site/components/typography_swatch/typography_swatch.scss
@@ -3,13 +3,42 @@
   border: solid 1px $spirit-color-grey-95;
   border-radius: $spirit-border-radius-l;
   margin: $spirit-space-stack-2-x;
+  overflow: hidden;
 }
 
 .spirit-doc-typography-swatch__sample-text {
   align-items: flex-start;
   display: flex;
   padding: $spirit-space-inset-3-x;
+  position: relative;
   word-break: break-word;
+
+  .spirit-doc-typography-swatch--space-highlighted & {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
+.spirit-doc-typography-swatch--space-highlighted {
+  background: $spirit-color-blue-15;
+}
+
+.spirit-doc-typography-swatch__highlight-space {
+  display: block;
+  position: absolute;
+  width: 100%;
+}
+
+.spirit-doc-typography-swatch__highlight-space--top {
+  background: $spirit-color-red-35;
+  left: 0;
+  top: 0;
+}
+
+.spirit-doc-typography-swatch__highlight-space--bottom {
+  background: $spirit-color-blue-30;
+  bottom: 0;
+  left: 0;
 }
 
 .spirit-doc-typography-swatch__sample-text-secondary {
@@ -59,5 +88,5 @@
 }
 
 .spirit-doc-typography-swatch__design-specs {
-  width: 170px;
+  width: 200px;
 }

--- a/doc-site/components/typography_swatch/typography_swatch.scss
+++ b/doc-site/components/typography_swatch/typography_swatch.scss
@@ -1,0 +1,63 @@
+.spirit-doc-typography-swatch {
+  @include spirit-box-sizing;
+  border: solid 1px $spirit-color-grey-95;
+  border-radius: $spirit-border-radius-l;
+  margin: $spirit-space-stack-2-x;
+}
+
+.spirit-doc-typography-swatch__sample-text {
+  align-items: flex-start;
+  display: flex;
+  padding: $spirit-space-inset-3-x;
+  word-break: break-word;
+}
+
+.spirit-doc-typography-swatch__sample-text-secondary {
+  display: block;
+  margin-left: auto;
+}
+
+.spirit-doc-typography-swatch__metadata {
+  align-items: flex-start;
+  background: $spirit-color-grey-95;
+  display: flex;
+  justify-content: space-between;
+  padding: $spirit-space-inset-3-x;
+}
+
+.spirit-doc-typography-swatch__title-wrap {
+  flex: 1 1 33%;
+
+  .spirit-doc-typography-swatch--no-design-specs & {
+    flex: 0 1 auto;
+  }
+}
+
+.spirit-doc-typography-swatch__title {
+  background: $spirit-color-white;
+  border-radius: $spirit-border-radius-s;
+  font-size: $spirit-font-size-s;
+  padding: $spirit-space-inset-half-x;
+}
+
+
+.spirit-doc-typography-swatch__code-sample {
+  @include spirit-doc-code-text;
+  background: none;
+  flex: 1 1 33%;
+  font-size: $spirit-font-size-s;
+  line-height: $spirit-font-line-height-body;
+  padding: 0;
+  text-align: center;
+}
+
+.spirit-doc-typography-swatch__design-specs-wrap {
+  display: flex;
+  flex: 1 1 33%;
+  justify-content: flex-end;
+  line-height: $spirit-font-line-height-body;
+}
+
+.spirit-doc-typography-swatch__design-specs {
+  width: 170px;
+}

--- a/doc-site/docs/doc-components/typography-swatches.njk
+++ b/doc-site/docs/doc-components/typography-swatches.njk
@@ -1,0 +1,29 @@
+{% extends 'templates/base.njk' %}
+{% block body %}
+  {% filter markdown %}
+      # Typography Swatch Demos
+  {% endfilter %}
+  <h2>Default Behavior</h2>
+
+  {{ spirit_doc.typography_swatch() }}
+
+  <h2>Custom Styles</h2>
+  {% set fancy_purple_styles %}
+    color: purple;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+  {% endset %}
+  {{ spirit_doc.typography_swatch(sample_text_styles=fancy_purple_styles) }}
+
+  <h2>Alphabet Sample Text</h2>
+  {{ spirit_doc.typography_swatch(alphabet_sample_text=true) }}
+
+  <h2>Alphabet Sample Text with secondary sample</h2>
+  {% set giant_characters %}
+    font-size: 200px;
+  {% endset %}
+  {{ spirit_doc.typography_swatch(alphabet_sample_text=true, secondary_sample_text="Jj", secondary_sample_text_styles=giant_characters) }}
+
+  <h2>Adding a class to the sample</h2>
+  {{ spirit_doc.typography_swatch(sample_text_class="spirit-h3") }}
+{% endblock body %}

--- a/doc-site/docs/doc-components/typography-swatches.njk
+++ b/doc-site/docs/doc-components/typography-swatches.njk
@@ -30,7 +30,11 @@
     position: relative;
     top: -5px;
   {% endset %}
-  {{ spirit_doc.typography_swatch(sample_text_class="spirit-h3", alphabet_sample_text=true, secondary_sample_text="Jj", secondary_sample_text_styles=giant_characters) }}
+  {{ spirit_doc.typography_swatch(
+    sample_text_class="spirit-h3", 
+    alphabet_sample_text=true, 
+    secondary_sample_text="Jj", 
+    secondary_sample_text_styles=giant_characters) }}
 
   <h2>Adding a class to the sample</h2>
   {{ spirit_doc.typography_swatch(sample_text_class="spirit-h3") }}
@@ -97,4 +101,21 @@
       title="Heading 3",
       code_sample=".spirit-h3<br/>@include spirit-h3;",
       design_specs="font-size: 32px;<br/>font-weight: bold;<br/>line-height: 40px;") }}
+
+  <h2>Hierarchy</h2>
+  {{ spirit_doc.typography_swatch(
+      title="Heading 1",
+      sample_text_class="spirit-h1",
+      highlighted_bottom_margin=spirit_tokens.space.generic['2-x'],
+      highlighted_top_margin=spirit_tokens.space.generic['5-x'],
+      code_sample=".long-form-text h1",
+      design_specs="margin: " + spirit_tokens.space.generic['5-x'] + " 0 " + spirit_tokens.space.generic['2-x'] + " 0;") }}
+
+  {{ spirit_doc.typography_swatch(
+      title="Heading 2",
+      sample_text_class="spirit-h2",
+      highlighted_bottom_margin=spirit_tokens.space.generic['2-x'],
+      highlighted_top_margin=spirit_tokens.space.generic['5-x'],
+      code_sample=".long-form-text h2",
+      design_specs="margin: " + spirit_tokens.space.generic['5-x'] + " 0 " + spirit_tokens.space.generic['2-x'] + " 0;") }}
 {% endblock body %}

--- a/doc-site/docs/doc-components/typography-swatches.njk
+++ b/doc-site/docs/doc-components/typography-swatches.njk
@@ -3,6 +3,11 @@
   {% filter markdown %}
       # Typography Swatch Demos
   {% endfilter %}
+  <style>
+    body {
+      padding: 20px;
+    }
+  </style>
   <h2>Default Behavior</h2>
 
   {{ spirit_doc.typography_swatch() }}
@@ -20,10 +25,76 @@
 
   <h2>Alphabet Sample Text with secondary sample</h2>
   {% set giant_characters %}
-    font-size: 200px;
+    font-size: 96px;
+    line-height: 1;
+    position: relative;
+    top: -5px;
   {% endset %}
-  {{ spirit_doc.typography_swatch(alphabet_sample_text=true, secondary_sample_text="Jj", secondary_sample_text_styles=giant_characters) }}
+  {{ spirit_doc.typography_swatch(sample_text_class="spirit-h3", alphabet_sample_text=true, secondary_sample_text="Jj", secondary_sample_text_styles=giant_characters) }}
 
   <h2>Adding a class to the sample</h2>
   {{ spirit_doc.typography_swatch(sample_text_class="spirit-h3") }}
+  
+  <h2>Weight</h2>
+  {% set sample_styles %}
+    font-size: 32px;
+    font-weight: {{ spirit_tokens.font.weight.regular }};
+  {% endset %}
+  {% set giant_characters %}
+    font-size: 96px;
+    line-height: 1;
+    position: relative;
+    top: -9px;
+    word-break: keep-all;
+  {% endset %}
+  {{ spirit_doc.typography_swatch(
+      alphabet_sample_text=true, 
+      sample_text_styles=sample_styles,
+      secondary_sample_text="Jj", 
+      secondary_sample_text_styles=giant_characters,
+      code_sample="font-weight: $spirit-font-weight-regular",
+      design_specs=false,
+      title="Regular") }}
+
+  {% set sample_styles %}
+    font-size: 32px;
+    font-weight: {{ spirit_tokens.font.weight.semibold }};
+  {% endset %}
+  {{ spirit_doc.typography_swatch(
+      alphabet_sample_text=true, 
+      sample_text_styles=sample_styles,
+      secondary_sample_text="Jj", 
+      secondary_sample_text_styles=giant_characters,
+      code_sample="font-weight: $spirit-font-weight-semibold",
+      design_specs=false,
+      title="Semibold") }}
+
+  {% set sample_styles %}
+    font-size: 32px;
+    font-weight: {{ spirit_tokens.font.weight.bold }};
+  {% endset %}
+  {{ spirit_doc.typography_swatch(
+      alphabet_sample_text=true, 
+      sample_text_styles=sample_styles,
+      secondary_sample_text="Jj", 
+      secondary_sample_text_styles=giant_characters,
+      code_sample="font-weight: $spirit-font-weight-bold",
+      design_specs=false,
+      title="Bold") }}
+
+  <h2>Scale</h2>
+  {{ spirit_doc.typography_swatch(
+      sample_text_class="spirit-h1") }}
+
+  {{ spirit_doc.typography_swatch(
+      sample_text_class="spirit-h2",
+      title="Heading 2",
+      code_sample=".spirit-h2<br/>@include spirit-h2;",
+      design_specs="font-size: 44px;<br/>font-weight: bold;<br/>line-height: 56px;") }}
+
+  {{ spirit_doc.typography_swatch(
+      sample_text_class="spirit-h3",
+      title="Heading 3",
+      code_sample=".spirit-h3<br/>@include spirit-h3;",
+      design_specs="font-size: 32px;<br/>font-weight: bold;<br/>line-height: 40px;") }}
 {% endblock body %}

--- a/doc-site/styles/spirit_doc_site.scss
+++ b/doc-site/styles/spirit_doc_site.scss
@@ -15,6 +15,7 @@
 @import '../components/site_nav/site_nav';
 @import '../components/tint_stack/tint_stack';
 @import '../components/token_table/token_table';
+@import '../components/typography_swatch/typography_swatch';
 
 
 @import 'docs/doc_template';


### PR DESCRIPTION
Sink page for the doc component is at:
`/doc-components/typography-swatches.html`

@jamesmelzer it should have all the options you need for the long form text and typography doc pages.