### PR TITLE
WIP LFT revision and compare sink

### DIFF
--- a/library/components/long-form-text/long-form-text.scss
+++ b/library/components/long-form-text/long-form-text.scss
@@ -226,3 +226,264 @@ $spirit-space-generic-2-x-half: 18px;
     margin-top: $spirit-space-generic-2-x * -1;
   }
 }
+
+
+.spirit-long-form-text-2 {
+  @include spirit-typography-reset;
+  @include clearfix;
+
+  h1 {
+    @include spirit-h1;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-5-x;
+  }
+
+  h2 {
+    @include spirit-h2;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-5-x;
+  }
+
+  h3 {
+    @include spirit-h3;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  h4 {
+    @include spirit-h4;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  h5 {
+    @include spirit-h5;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  h6 {
+    @include spirit-h6;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  .spirit-subhead {
+    @include spirit-subhead;
+    margin-bottom: $spirit-space-generic-4-x;
+    margin-top: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  p,
+  .spirit-body-l {
+    @include spirit-body-text-l;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+  }
+
+  .spirit-body-m {
+    @include spirit-body-text-m;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+  }
+
+  small,
+  .spirit-body-s {
+    @include spirit-body-text-s;
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+  }
+
+  a {
+    @include spirit-dark-parent-light-text;
+    color: $spirit-text-color-link;
+    font-weight: $spirit-font-weight-bold;
+    text-decoration: none;
+
+    &:focus {
+      outline: $spirit-border-width-input-focus solid $spirit-interactive-color-focus-soft;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ol,
+  ul {
+    @include spirit-typography-reset;
+    margin-bottom: $spirit-space-generic-2-x-half;
+    margin-top: 0;
+    padding: 0 0 0 36px;
+
+    ol,
+    ul {
+      margin-bottom: 0;
+      margin-top: 0;
+    }
+  }
+
+  ul {
+    list-style-type: disc;
+
+    ul {
+      list-style-type: circle;
+
+      ul {
+        list-style-type: disc;
+
+        ul {
+          list-style-type: circle;
+
+          // sass-lint:disable nesting-depth
+          ul {
+            list-style-type: disc;
+
+            ul {
+              list-style-type: circle;
+            }
+          }
+          // sass-lint:enable nesting-depth
+        }
+      }
+    }
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  li {
+    @include spirit-typography-reset(
+      $font-size: $spirit-font-size-l
+    );
+    @include spirit-body-text-l;
+    @include spirit-dark-parent-light-text;
+    margin-top: 0;
+  }
+
+  blockquote {
+    @include spirit-h3;
+    margin-left: 0;
+    margin-right: 0;
+    padding-top: $spirit-space-generic-2-x;
+  }
+
+  @mixin float-item {
+    max-width: 50%;
+    width: 352px;
+  }
+
+  @mixin float-item-left {
+    float: left;
+    margin: $spirit-space-generic-3-x $spirit-space-generic-4-x $spirit-space-generic-4-x 0;
+  }
+
+  @mixin float-item-right {
+    float: right;
+    margin: $spirit-space-generic-3-x 0 $spirit-space-generic-4-x $spirit-space-generic-4-x;
+  }
+
+  .spirit-pull-quote-left,
+  .spirit-pull-quote-right {
+    @include float-item;
+  }
+
+  .spirit-pull-quote-left {
+    @include float-item-left;
+  }
+
+  .spirit-pull-quote-right {
+    @include float-item-right;
+  }
+
+  img {
+    display: block;
+    margin-bottom: $spirit-space-generic-4-x;
+    margin-top: $spirit-space-generic-2-x;
+    max-width: 100%;
+  }
+
+  .spirit-image-left,
+  .spirit-image-right {
+    @include float-item;
+  }
+
+  .spirit-image-left {
+    @include float-item-left;
+  }
+
+  .spirit-image-right {
+    @include float-item-right;
+  }
+
+  .spirit-image-left img,
+  .spirit-image-right img {
+    margin-top: 0;
+  }
+
+  .spirit-image-left .spirit-caption,
+  .spirit-image-right .spirit-caption {
+    margin-bottom: 0;
+  }
+
+  .spirit-embed-video {
+    height: 0;
+    margin-bottom: $spirit-space-generic-4-x;
+    margin-top: $spirit-space-generic-2-x;
+    max-width: 100%;
+    overflow: hidden;
+    padding-bottom: 56.25%;
+    position: relative;
+  }
+
+  .spirit-embed-video iframe,
+  .spirit-embed-video object,
+  .spirit-embed-video embed {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  .spirit-caption {
+    @include spirit-body-text-s;
+    margin-bottom: $spirit-space-generic-4-x;
+    margin-top: $spirit-space-generic-2-x;
+  }
+
+  figure {
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: $spirit-space-generic-2-x;
+  }
+
+  figure > .spirit-caption {
+    margin-top: $spirit-space-generic-2-x * -1;
+  }
+
+  h2 + h3,
+  h2 + h4,
+  h2 + h5,
+  h2 + h6, 
+
+  h3 + h4,
+  h3 + h5,
+  h3 + h6, 
+
+  h4 + h5,
+  h4 + h6,
+
+  h5 + h6,  {
+    padding-top: 0;
+  }
+}
+

--- a/library/docs/sink-pages/components/long-form-text-2.njk
+++ b/library/docs/sink-pages/components/long-form-text-2.njk
@@ -1,0 +1,454 @@
+{% extends "templates/sink.njk" %}
+{% block body %}
+    <link rel="stylesheet" href="/styles/long-form-text-sink-page.css">
+    {% filter markdown(true, "hostile-sink-reset") %}
+        # Long Form Text Sink
+    {% endfilter %}
+    <div class="spirit-container">
+        <div class="spirit-container__inner spirit-container__inner--padding-top-xs spirit-container__inner--padding-bottom-xs" style="max-width: 1400px;">
+            <div class="spirit-long-form-text">
+                <h3>What changed in "revised" LFT?</h3>
+                <ol>
+                    <li>All LFT top margins set to 0 (removes the default spacing in the reset file)</li>
+                    <li>Set the intentional top spacing using padding, not margin (on headings, mostly)</li>
+                    <li>Any descending heading combination (e.g. h2 + h3) sets the top padding to zero. This works like margin collapse, but more predictably in a fixed set of scenarios.</li>
+                    <li>List items are now the same color as body text.</li>
+                </ol>
+                <p>As you can see in this side-by-side comparison, the changes are subtle.</p>
+            </div>
+        </div>
+        <div class="spirit-container__inner spirit-container__inner--padding-top-xs" style="max-width: 1400px;">
+
+            <div class="spirit-row">
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Original
+                    {% endfilter %}
+                    <div class="spirit-long-form-text">
+
+                        <h1>
+                            You Can Help Turn Type One Into Type None
+                        </h1>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h2>
+                            You Can Help Turn Type One Into Type None
+                        </h2>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h4>
+                            You Can Help Turn Type One Into Type None
+                        </h4>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h5>
+                            You Can Help Turn Type One Into Type None
+                        </h5>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h6>
+                            You Can Help Turn Type One Into Type None
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        </h6>
+                        <h2>
+                            You Can Help Turn Type One Into Type None
+                        </h2>
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <h4>
+                            You Can Help Turn Type One Into Type None
+                        </h4>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+
+                        <h1>
+                            You Can Help Turn Type One Into Type None
+                        </h1>
+                        <p class="spirit-subhead">Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque est tempor nec.</p>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. </p>
+
+                        <p class="spirit-body-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+
+                        <p class="spirit-body-s">You can use the <code>spirit-body-s</code> class. Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. Quisque sit amet aliquet nulla. Fusce luctus purus gravida rutrum laoreet. Phasellus in ipsum nibh. Proin tellus lorem, convallis nec sodales id, feugiat non erat. Aenean viverra nisl quis dignissim fermentum. Aliquam porta augue bibendum arcu suscipit, ac porttitor arcu venenatis. Fusce luctus, magna vitae ultrices convallis, nunc leo aliquam orci, ac viverra nisl neque pretium dolor.</p>
+
+                        <p class="spirit-body-s">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ul>
+
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps List item 2 is very long so that it wraps List
+                                item 2 is very long so that it wraps List item 2 is very long so that it wraps
+                            </li>
+                            <li>List item 3
+                                <ul>
+                                    <li>Nested List item 1</li>
+                                    <li>Nested List item 2</li>
+                                    <li>Nested List item 3
+                                        <ul>
+                                            <li>Nested List item 1</li>
+                                            <li>Nested List item 2 is very long so that it wraps Nested List item 2 is very
+                                                long so that it wraps Nested List item 2 is very long so that it wraps
+                                                Nested List item 2 is very long so that it wraps
+                                            </li>
+                                            <li>Nested List item 3</li>
+                                        </ul>
+                                    </li>
+                                    <li>Nested List item 4</li>
+                                </ul>
+                            </li>
+                            <li>List item 4</li>
+                        </ul>
+
+                        <p>Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. </p>
+                        <p>Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ul>
+                        <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ol>
+
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps List item 2 is very long so that it wraps List
+                                item 2 is very long so that it wraps List item 2 is very long so that it wraps
+                            </li>
+                            <li>List item 3
+                                <ol>
+                                    <li>Nested List item 1</li>
+                                    <li>Nested List item 2</li>
+                                    <li>Nested List item 3
+                                        <ol>
+                                            <li>Nested List item 1</li>
+                                            <li>Nested List item 2 is very long so that it wraps Nested List item 2 is very
+                                                long so that it wraps Nested List item 2 is very long so that it wraps
+                                                Nested List item 2 is very long so that it wraps
+                                            </li>
+                                            <li>Nested List item 3</li>
+                                        </ol>
+                                    </li>
+                                    <li>Nested List item 4</li>
+                                </ol>
+                            </li>
+                            <li>List item 4</li>
+                        </ol>
+                        <p>Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. </p>
+                        <p>Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ol>
+                        <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+                    </div>
+
+                </div>
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Revised
+                    {% endfilter %}
+                    <div class="spirit-long-form-text-2">
+                        <h1>
+                            You Can Help Turn Type One Into Type None
+                        </h1>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h2>
+                            You Can Help Turn Type One Into Type None
+                        </h2>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h4>
+                            You Can Help Turn Type One Into Type None
+                        </h4>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h5>
+                            You Can Help Turn Type One Into Type None
+                        </h5>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        <h6>
+                            You Can Help Turn Type One Into Type None
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+                        </h6>
+                        <h2>
+                            You Can Help Turn Type One Into Type None
+                        </h2>
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+
+                        <h3>
+                            You Can Help Turn Type One Into Type None
+                        </h3>
+                        <h4>
+                            You Can Help Turn Type One Into Type None
+                        </h4>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+
+                        <h1>
+                            You Can Help Turn Type One Into Type None
+                        </h1>
+                        <p class="spirit-subhead">Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque est tempor nec.</p>
+                        <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. </p>
+
+                        <p class="spirit-body-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+
+                        <p class="spirit-body-s">You can use the <code>spirit-body-s</code> class. Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. Quisque sit amet aliquet nulla. Fusce luctus purus gravida rutrum laoreet. Phasellus in ipsum nibh. Proin tellus lorem, convallis nec sodales id, feugiat non erat. Aenean viverra nisl quis dignissim fermentum. Aliquam porta augue bibendum arcu suscipit, ac porttitor arcu venenatis. Fusce luctus, magna vitae ultrices convallis, nunc leo aliquam orci, ac viverra nisl neque pretium dolor.</p>
+
+                        <p class="spirit-body-s">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ul>
+
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps List item 2 is very long so that it wraps List
+                                item 2 is very long so that it wraps List item 2 is very long so that it wraps
+                            </li>
+                            <li>List item 3
+                                <ul>
+                                    <li>Nested List item 1</li>
+                                    <li>Nested List item 2</li>
+                                    <li>Nested List item 3
+                                        <ul>
+                                            <li>Nested List item 1</li>
+                                            <li>Nested List item 2 is very long so that it wraps Nested List item 2 is very
+                                                long so that it wraps Nested List item 2 is very long so that it wraps
+                                                Nested List item 2 is very long so that it wraps
+                                            </li>
+                                            <li>Nested List item 3</li>
+                                        </ul>
+                                    </li>
+                                    <li>Nested List item 4</li>
+                                </ul>
+                            </li>
+                            <li>List item 4</li>
+                        </ul>
+
+                        <p>Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. </p>
+                        <p>Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+                        <ul>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ul>
+                        <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ol>
+
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps List item 2 is very long so that it wraps List
+                                item 2 is very long so that it wraps List item 2 is very long so that it wraps
+                            </li>
+                            <li>List item 3
+                                <ol>
+                                    <li>Nested List item 1</li>
+                                    <li>Nested List item 2</li>
+                                    <li>Nested List item 3
+                                        <ol>
+                                            <li>Nested List item 1</li>
+                                            <li>Nested List item 2 is very long so that it wraps Nested List item 2 is very
+                                                long so that it wraps Nested List item 2 is very long so that it wraps
+                                                Nested List item 2 is very long so that it wraps
+                                            </li>
+                                            <li>Nested List item 3</li>
+                                        </ol>
+                                    </li>
+                                    <li>Nested List item 4</li>
+                                </ol>
+                            </li>
+                            <li>List item 4</li>
+                        </ol>
+                        <p>Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. </p>
+                        <p>Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+                        <ol>
+                            <li>List item 1</li>
+                            <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                            </li>
+                            <li>List item 3</li>
+                            <li>List item 4</li>
+                        </ol>
+                        <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+
+        <div class="spirit-container__inner spirit-container__inner--padding-top-xs" style="max-width: 1400px;">
+
+            <div class="spirit-row">
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Original
+                    {% endfilter %}
+                    <div class="spirit-long-form-text">
+                        <h1>Type 1 diabetes low blood sugar symptoms</h1>
+                        <p class="spirit-subhead">Type 1 diabetes in an autoimmune disease where a person’s pancreas doesn’t produce insulin—a hormone needed to convert food into energy. It affects children and adults, comes on suddenly, and it cannot be prevented or cured. Hypoglycemia, or low blood sugar, is a common and dangerous occurance with type 1 diabetes. If your blood sugar gets too low it may lead to insulin shock, which is life-threatening if not cared for. Low blood sugar can happen when your body has too little food—or glucose—or when it produces too much insulin.</p>
+                        <h2>Type 1 diabetes hypoglycemia symptoms</h2>
+                        <p>So what are the low blood sugar symptoms you should look out for? It’s important to realize that the signs of low blood sugar will vary depending on the person. However, people with type 1 diabetes—whether it’s been diagnosed or not—may experience one or more of the following:</p>
+                        <ul>
+                            <li>Sweating and shaking</li>
+                            <li>Blurry vision</li>
+                            <li>Poor coordination</li>
+                            <li>Dizziness or feeling lightheaded</li>
+                            <li>Difficulty concentrating</li>
+                            <li>Feeling anxious or irritable</li>
+                            <li>Hunger or nausea</li>
+                            <li>Erratic changes in behavior</li>
+                        </ul>
+                        <h2>What to do if you experience low blood glucose symptoms</h2>
+                        <p>Severely low blood-sugar levels can lead to hypoglycemic seizures, unconsciousness, coma, and death if left untreated. That’s why it’s important to see a doctor if you think you have low blood sugar so he or she can check your blood-glucose levels—look into whether type 1 diabetes may be a cause—and provide the necessary treatment.</p>
+                    </div>
+
+                </div>
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Revised
+                    {% endfilter %}
+                    <div class="spirit-long-form-text-2">
+                        <h1>Type 1 diabetes low blood sugar symptoms</h1>
+                        <p class="spirit-subhead">Type 1 diabetes in an autoimmune disease where a person’s pancreas doesn’t produce insulin—a hormone needed to convert food into energy. It affects children and adults, comes on suddenly, and it cannot be prevented or cured. Hypoglycemia, or low blood sugar, is a common and dangerous occurance with type 1 diabetes. If your blood sugar gets too low it may lead to insulin shock, which is life-threatening if not cared for. Low blood sugar can happen when your body has too little food—or glucose—or when it produces too much insulin.</p>
+                        <h2>Type 1 diabetes hypoglycemia symptoms</h2>
+                        <p>So what are the low blood sugar symptoms you should look out for? It’s important to realize that the signs of low blood sugar will vary depending on the person. However, people with type 1 diabetes—whether it’s been diagnosed or not—may experience one or more of the following:</p>
+                        <ul>
+                            <li>Sweating and shaking</li>
+                            <li>Blurry vision</li>
+                            <li>Poor coordination</li>
+                            <li>Dizziness or feeling lightheaded</li>
+                            <li>Difficulty concentrating</li>
+                            <li>Feeling anxious or irritable</li>
+                            <li>Hunger or nausea</li>
+                            <li>Erratic changes in behavior</li>
+                        </ul>
+                        <h2>What to do if you experience low blood glucose symptoms</h2>
+                        <p>Severely low blood-sugar levels can lead to hypoglycemic seizures, unconsciousness, coma, and death if left untreated. That’s why it’s important to see a doctor if you think you have low blood sugar so he or she can check your blood-glucose levels—look into whether type 1 diabetes may be a cause—and provide the necessary treatment.</p>
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+        <div class="spirit-container__inner spirit-container__inner--padding-top-xs" style="max-width: 1400px;">
+
+            <div class="spirit-row">
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Original
+                    {% endfilter %}
+                    <div class="spirit-long-form-text">
+                        <h2 id="sizes">Sizes</h2>
+                        <p>Scale buttons according to visual priority and available real estate. Text and icons scale with the overall button and are not independently configurable. </p>
+                        <p>The medium default size can be modified with <code>.spirit-button--extra-small</code>, <code>.spirit-button--small</code>, and <code>.spirit-button--large</code>. Icon only buttons are only available in small and default. </p>
+                        <h4 id="extra-small">Extra Small</h4>
+                        
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text">
+                        <h4 id="extra-small">Small</h4>
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text">
+                        <h2 id="guidelines">Guidelines</h2>
+                        <h3 id="use-when">Use When</h3>
+                        <ul>
+                        <li>To activate or trigger an action</li>
+                        <li>To initiate a task</li>
+                        <li>To elevate the visibility of a navigation link, particularly the ubiquitous “Learn More”</li>
+                        <li>To cancel or dismiss something</li>
+                        </ul>
+                        <h3 id="editorial">Editorial</h3>
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text">
+                        <h3 id="accessibility">Accessibility</h3>
+                        <ul>
+                        <li>Use the <code>aria-label</code> attribute on the SVG within an icon only button. See <a href="/visual-style/icons.html">icons</a> for additional guidance. </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="spirit-col-lg-6">
+                    {% filter markdown(true, "hostile-sink-reset") %}
+                        ## Revised
+                    {% endfilter %}
+                    <div class="spirit-long-form-text-2">
+                        <h2 id="sizes">Sizes</h2>
+                        <p>Scale buttons according to visual priority and available real estate. Text and icons scale with the overall button and are not independently configurable. </p>
+                        <p>The medium default size can be modified with <code>.spirit-button--extra-small</code>, <code>.spirit-button--small</code>, and <code>.spirit-button--large</code>. Icon only buttons are only available in small and default. </p>
+                        <h4 id="extra-small">Extra Small</h4>
+                        
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text-2">
+                        <h4 id="extra-small">Small</h4>
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text-2">
+                        <h2 id="guidelines">Guidelines</h2>
+                        <h3 id="use-when">Use When</h3>
+                        <ul>
+                        <li>To activate or trigger an action</li>
+                        <li>To initiate a task</li>
+                        <li>To elevate the visibility of a navigation link, particularly the ubiquitous “Learn More”</li>
+                        <li>To cancel or dismiss something</li>
+                        </ul>
+                        <h3 id="editorial">Editorial</h3>
+                    </div>
+                    <div class="spirit-left-sink-placeholder"></div>
+                    <div class="spirit-long-form-text-2">
+                        <h3 id="accessibility">Accessibility</h3>
+                        <ul>
+                        <li>Use the <code>aria-label</code> attribute on the SVG within an icon only button. See <a href="/visual-style/icons.html">icons</a> for additional guidance. </li>
+                        </ul>
+                    </div>
+
+                </div>
+            </div>
+
+        </div>
+
+    </div>
+
+{% endblock %}

--- a/library/styles/long-form-text-sink-page.scss
+++ b/library/styles/long-form-text-sink-page.scss
@@ -7,4 +7,10 @@
     color: $spirit-color-white;
   }
 }
+.spirit-left-sink-placeholder {
+    background: $spirit-color-grey-95;
+    border-radius: 6px;
+    margin: 0;
+    height: 100px;
+}
 


### PR DESCRIPTION
I created a side-by-side comparison page called long-form-text-2.html that shows original and revised LFT. 

What changed? 

- All LFT top margins set to 0 (removes the default spacing in the reset file)
- Set the intentional top spacing using padding, not margin (on headings, mostly)
- Any descending heading combination (e.g. h2 + h3) sets the top padding to zero. This works like margin collapse, but more predictably in a fixed set of scenarios.
- List items are now the same color as body text.