### PR TITLE
#255 Add correct case for scroll monitor JS dependency

### DIFF
--- a/doc-site/templates/base.njk
+++ b/doc-site/templates/base.njk
@@ -26,7 +26,7 @@
         <script src="/scripts/dependencies/prism-scss.min.js"></script>
         <script src="/scripts/dependencies/prism-twig.min.js"></script>
         <script src="/scripts/dependencies/svg4everybody.min.js"></script>
-        <script src="/scripts/dependencies/scrollmonitor.js"></script>
+        <script src="/scripts/dependencies/scrollMonitor.js"></script>
         <script src="/scripts/dependencies/smoothscroll.min.js"></script>
         <script>
             svg4everybody();


### PR DESCRIPTION
Easiest PR you'll review all year! Changed a single character.

This is what happens when the MacOS file system is case-insensitive but your server is not.