### PR TITLE
feature/283-lft-button-colors

### DIFF
--- a/library/components/long-form-text/long-form-text.scss
+++ b/library/components/long-form-text/long-form-text.scss
@@ -35,7 +35,6 @@
     &.spirit-lead-heading {
       @include spirit-lead-heading;
     }
-    
   }
 
   h4 {
@@ -86,7 +85,7 @@
     margin-top: 0;
   }
 
-  a {
+  a:not(.spirit-button) {
     @include spirit-dark-parent-light-text;
     color: $spirit-text-color-link;
     font-weight: $spirit-font-weight-bold;

--- a/library/docs/sink-pages/components/long-form-text.njk
+++ b/library/docs/sink-pages/components/long-form-text.njk
@@ -217,6 +217,22 @@
                             <li>List item 4</li>
                         </ol>
                         <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+
+                        {% filter markdown(true, "hostile-sink-reset") %}
+                            #### Buttons
+                        {% endfilter %}
+
+                        <p>{{ library.button(text="Default Button") }}</p>
+                        <p>{{ library.button(class="spirit-button--secondary", text="Secondary Button") }}</p>
+                        <p>{{ library.button(class="spirit-button--minimal", text="Minimal Button") }}</p>
+
+                        {% filter markdown(true, "hostile-sink-reset") %}
+                            #### Buttons as links
+                        {% endfilter %}
+
+                        <p>{{ library.button(text="Default Button", href="#") }}</p>
+                        <p>{{ library.button(class="spirit-button--secondary", text="Secondary Button", href="#") }}</p>
+                        <p>{{ library.button(class="spirit-button--minimal", text="Minimal Button", href="#") }}</p>
                     </div>
 
                 </div>
@@ -429,6 +445,22 @@
                             <li>List item 4</li>
                         </ol>
                         <p>Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. </p>
+
+                        {% filter markdown(true, "hostile-sink-reset") %}
+                            #### Buttons
+                        {% endfilter %}
+
+                        <p>{{ library.button(text="Default Button") }}</p>
+                        <p>{{ library.button(class="spirit-button--secondary", text="Secondary Button") }}</p>
+                        <p>{{ library.button(class="spirit-button--minimal", text="Minimal Button") }}</p>
+
+                        {% filter markdown(true, "hostile-sink-reset") %}
+                            #### Buttons as links
+                        {% endfilter %}
+
+                        <p>{{ library.button(text="Default Button", href="#") }}</p>
+                        <p>{{ library.button(class="spirit-button--secondary", text="Secondary Button", href="#") }}</p>
+                        <p>{{ library.button(class="spirit-button--minimal", text="Minimal Button", href="#") }}</p>
                     </div>
 
                 </div>


### PR DESCRIPTION
Remove long-form text color overrides of spirit-button when a link.

To test:
Added buttons to first two sections of the long form text sink page:
`/sink-pages/components/long-form-text.html`