### PR TITLE
feature/#320-button-block-level

### DIFF
--- a/doc-site/docs/components/buttons.njk
+++ b/doc-site/docs/components/buttons.njk
@@ -612,6 +612,11 @@
         class: '.spirit-button--[size]',
         applies_to: '.spirit-button',
         outcome: 'Applies button size styles. Use `--extra-small`, `--small`,  `--large.` Default size is implied and does not need to be specified.'
+      },
+      {
+        class: '.spirit-button--fullwidth',
+        applies_to: '.spirit-button',
+        outcome: 'Applies 100% width to button.'
       }
     ]) }}
 

--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -12,7 +12,8 @@
       feedbackType=false,
       feedbackText=false,
       name=false,
-      value=false
+      value=false,
+      fullwidth=false
       ) %}
   {% if href %}
     {% set el = 'a' %}
@@ -34,7 +35,7 @@
     <input {{ 'id=' + id if id }} {{ 'type=' + el }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--is-icon' if icon and not text}}" value="{{text if text}}" {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} />
   {% elif el %}
     {# Using type variable for <button type="submit"> or <a type="button"> options #}
-    <{{el}} {{ 'id=' + id if id }} {{ 'type=' + type if type }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--is-icon' if icon and not text}}" {{ 'href=' + href if href }} {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} {{ 'disabled' if disabled }}>
+    <{{el}} {{ 'id=' + id if id }} {{ 'type=' + type if type }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--is-icon' if icon and not text}}" {{ 'href=' + href if href }} {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} {{ 'disabled' if disabled }}>
       {% if iconName %}
         {% if not iconLabel %}
           {% set iconLabel = iconName %}

--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -134,6 +134,10 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   }
 }
 
+.spirit-button--fullwidth {
+  width: 100%;
+}
+
 .spirit-button__default-text {
   .spirit-button__success-text[aria-hidden='false'] + & {
     display: none;

--- a/library/docs/sink-pages/components/buttons.njk
+++ b/library/docs/sink-pages/components/buttons.njk
@@ -239,6 +239,11 @@
                 {% endfilter %}
                 {{ library.button(class="spirit-button--large-lg", text="Learn More") }}
 
+                {% filter markdown(true, "hostile-sink-reset") %}
+                    ### Full Width
+                {% endfilter %}
+                {{ library.button(text="Learn More", fullwidth="true") }}
+
             </div>
 
             <div class="spirit-col spirit-col-md-6 spirit-col-lg-4">


### PR DESCRIPTION
Issue request is to make block level button option. After investigation, in-line buttons and block level buttons collapse margins differently. Therefore, created a new class option for `spirit-button--fullwidth` to give 100% width to the standard inline spirit button. 

I also added the class reference to the button page in the doc site. I did not, however, update any further documentation or use of this class in the button doc page. If this is required, will need further direction or recommend adding new issue to do so. 

* have to gulp in library
* for doc site ( after library compiled ):
  -- `npm run unlink-local-library`
  -- `npm run link-local-library`
  -- `gulp`


See: 
`/sink-pages/components/buttons.html` in library
`/components/buttons.html` in doc site