### PR TITLE
Feature/#315 card object fit refactor

### DIFF
--- a/library/components/card/card.njk
+++ b/library/components/card/card.njk
@@ -9,7 +9,8 @@
         link_text="Find a Walk Near You",
         cta,
         size,
-        aria_label
+        aria_label,
+        caption="hello"
         ) %}
   {% if cta == undefined %}
     {% set cta %}
@@ -27,12 +28,17 @@
 
   <a href="{{ href }}" class="spirit-card{{ ' ' + class if class }}{{ ' ' + size_class if size_class }}" aria-label="{{ aria_label }}">
     {% if img_src %}
-      <span class="spirit-card__image-wrap">
-        {% if img_src_list_item %}
-          <img class="spirit-card__image-list-item" src="{{ img_src_list_item }}" alt="{{ img_alt_text }}">
-        {% endif %}
-        <img class="spirit-card__image" src="{{ img_src }}" alt="{{ img_alt_text }}">
-      </span>
+      <figure class="spirit-card__image-wrap spirit-object-fit" itemprop="image" itemtype="http://schema.org/ImageObject">
+        <div class="spirit-object-fit__image-contain">
+          {% if img_src_list_item %}
+            <img class="spirit-card__image-list-item" src="{{ img_src_list_item }}" alt="{{ img_alt_text }}">
+          {% endif %}
+          <img class="spirit-card__image" src="{{ img_src }}" alt="{{ img_alt_text }}">
+        </div>
+          {% if caption %}
+            <figcaption class="spirit-card__figcaption spirit-caption">{{ caption }}</figcaption>
+          {% endif %}
+      </figure>
     {% endif %}
     <span class="spirit-card__text">
       <h3 class="spirit-card__title">{{ title_text | safe }}</h3>

--- a/library/components/card/card.njk
+++ b/library/components/card/card.njk
@@ -9,8 +9,7 @@
         link_text="Find a Walk Near You",
         cta,
         size,
-        aria_label,
-        caption="hello"
+        aria_label
         ) %}
   {% if cta == undefined %}
     {% set cta %}

--- a/library/components/card/card.njk
+++ b/library/components/card/card.njk
@@ -1,7 +1,7 @@
 {% macro card(
         class=false,
         href="#",
-        img_src="/images/components/card/walkers.png",
+        img_src="/images/components/container/800x800.png",
         img_src_list_item,
         img_alt_text="JDRF Walkers",
         title_text="JDRF One Walk&reg;",

--- a/library/components/card/card.njk
+++ b/library/components/card/card.njk
@@ -28,17 +28,12 @@
 
   <a href="{{ href }}" class="spirit-card{{ ' ' + class if class }}{{ ' ' + size_class if size_class }}" aria-label="{{ aria_label }}">
     {% if img_src %}
-      <figure class="spirit-card__image-wrap spirit-object-fit" itemprop="image" itemtype="http://schema.org/ImageObject">
-        <div class="spirit-object-fit__image-contain">
-          {% if img_src_list_item %}
-            <img class="spirit-card__image-list-item" src="{{ img_src_list_item }}" alt="{{ img_alt_text }}">
-          {% endif %}
-          <img class="spirit-card__image" src="{{ img_src }}" alt="{{ img_alt_text }}">
-        </div>
-          {% if caption %}
-            <figcaption class="spirit-card__figcaption spirit-caption">{{ caption }}</figcaption>
-          {% endif %}
-      </figure>
+      <span class="spirit-card__image-wrap">
+        {% if img_src_list_item %}
+          <img class="spirit-card__image-list-item" src="{{ img_src_list_item }}" alt="{{ img_alt_text }}">
+        {% endif %}
+        <img class="spirit-card__image" src="{{ img_src }}" alt="{{ img_alt_text }}">
+      </span>
     {% endif %}
     <span class="spirit-card__text">
       <h3 class="spirit-card__title">{{ title_text | safe }}</h3>

--- a/library/components/card/card.scss
+++ b/library/components/card/card.scss
@@ -7,7 +7,7 @@ $spirit-card-title-line-height-medium: 32px;
 $spirit-card-title-line-height-large: 40px;
 $spirit-card-cta-line-height-small: 20px;
 $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-secondary;
-$spirit-card-list-image-width-sm: 72px;
+$spirit-card-list-image-size-sm: 72px;
 
 @mixin spirit-card-list-item {
   @include spirit-elevation(0, $spirit-elevation-color-blue);
@@ -39,11 +39,11 @@ $spirit-card-list-image-width-sm: 72px;
   .spirit-card__image-wrap {
     display: block;
     flex-shrink: 0;
-    height: $spirit-card-list-image-width-sm;
+    height: $spirit-card-list-image-size-sm;
     margin: $spirit-space-inline-right-1-x;
     padding: 0;
     position: relative;
-    width: $spirit-card-list-image-width-sm;
+    width: $spirit-card-list-image-size-sm;
   }
 
   .spirit-card__title {

--- a/library/components/card/card.scss
+++ b/library/components/card/card.scss
@@ -37,10 +37,12 @@ $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-se
 
   .spirit-card__image-wrap {
     flex-shrink: 0;
-    height: 72px;
+    width: 72px;
+    display: block;
     margin: $spirit-space-inline-right-1-x;
     position: relative;
-    width: 72px;
+    height: 72px;
+    padding: 0;
   }
 
   .spirit-card__title {
@@ -241,7 +243,12 @@ $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-se
   overflow: hidden;
   position: relative;
   width: 100%;
+  padding-top: $spirit-ratio-wide;
   z-index: 2; // Needed to preserve border radius crop while image is scaled on hover
+}
+
+.spirit-card__image-contain {
+  // @TODO CREATE MACRO FOR OBJECT FIT IMAGE
 }
 
 .spirit-card__image {
@@ -249,6 +256,9 @@ $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-se
   height: 100%;
   object-fit: cover;
   width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 
 .spirit-card__image-list-item {

--- a/library/components/card/card.scss
+++ b/library/components/card/card.scss
@@ -7,6 +7,7 @@ $spirit-card-title-line-height-medium: 32px;
 $spirit-card-title-line-height-large: 40px;
 $spirit-card-cta-line-height-small: 20px;
 $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-secondary;
+$spirit-card-list-image-width-sm: 72px;
 
 @mixin spirit-card-list-item {
   @include spirit-elevation(0, $spirit-elevation-color-blue);
@@ -36,13 +37,13 @@ $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-se
   }
 
   .spirit-card__image-wrap {
-    flex-shrink: 0;
-    width: 72px;
     display: block;
+    flex-shrink: 0;
+    height: $spirit-card-list-image-width-sm;
     margin: $spirit-space-inline-right-1-x;
-    position: relative;
-    height: 72px;
     padding: 0;
+    position: relative;
+    width: $spirit-card-list-image-width-sm;
   }
 
   .spirit-card__title {
@@ -241,24 +242,20 @@ $spirit-card-list-text-box-shadow: inset 0 -1px 0 0 $spirit-interactive-color-se
   flex-shrink: 0;
   margin: $spirit-space-stack-1-x;
   overflow: hidden;
+  padding-top: $spirit-ratio-wide;
   position: relative;
   width: 100%;
-  padding-top: $spirit-ratio-wide;
   z-index: 2; // Needed to preserve border radius crop while image is scaled on hover
-}
-
-.spirit-card__image-contain {
-  // @TODO CREATE MACRO FOR OBJECT FIT IMAGE
 }
 
 .spirit-card__image {
   display: block;
   height: 100%;
-  object-fit: cover;
-  width: 100%;
-  position: absolute;
   left: 0;
+  object-fit: cover;
+  position: absolute;
   top: 0;
+  width: 100%;
 }
 
 .spirit-card__image-list-item {

--- a/library/docs/sink-pages/components/card-grids.njk
+++ b/library/docs/sink-pages/components/card-grids.njk
@@ -1,4 +1,11 @@
 {% extends "templates/sink.njk" %}
+{% block head_content_append %}
+  
+  <script>
+  // Add polyfill for object fit - able to test sink on ie
+  this.fitie=function(t){function e(){c.call(t,g+m,e);var a={boxSizing:"content-box",display:"inline-block",overflow:"hidden"};"backgroundColor backgroundImage borderColor borderStyle borderWidth bottom fontSize lineHeight height left opacity margin position right top visibility width".replace(/\w+/g,function(t){a[t]=l[t]}),d.border=d.margin=d.padding=0,d.display="block",d.height=d.width="auto",d.opacity=1;var h=t.videoWidth||t.width,s=t.videoHeight||t.height,u=h/s,v=document.createElement("object-fit");v.appendChild(t.parentNode.replaceChild(v,t));for(var p in a)v.runtimeStyle[p]=a[p];var b;"fill"===i?f?(d.width=o,d.height=n):(d["-ms-transform-origin"]="0% 0%",d["-ms-transform"]="scale("+o/h+","+n/s+")"):(r>u?"contain"===i:"cover"===i)?(b=n*u,d.width=Math.round(b)+"px",d.height=n+"px",d.marginLeft=Math.round((o-b)/2)+"px"):(b=o/u,d.width=o+"px",d.height=Math.round(b)+"px",d.marginTop=Math.round((n-b)/2)+"px")}var i=t.currentStyle["object-fit"];if(i&&/^(contain|cover|fill)$/.test(i)){var o=t.clientWidth,n=t.clientHeight,r=o/n,a=t.nodeName.toLowerCase(),d=t.runtimeStyle,l=t.currentStyle,h=t.addEventListener||t.attachEvent,c=t.removeEventListener||t.detachEvent,g=t.addEventListener?"":"on",f="img"===a,m=f?"load":"loadedmetadata";h.call(t,g+m,e),t.complete&&e()}},this.fitie.init=function(){if(document.body)for(var t=document.querySelectorAll("img,video"),e=-1;t[++e];)fitie(t[e]);else setTimeout(fitie.init)},/MSIE|Trident/.test(navigator.userAgent)&&this.fitie.init();
+  </script>
+{% endblock head_content_append %}
 {% block body %}
   <style>
     body {

--- a/library/tokens/tokens.yaml
+++ b/library/tokens/tokens.yaml
@@ -243,7 +243,12 @@ font :
         normal:        1.231
         breakpoint-l : 1.25
 
-
+ratio:
+  portrait : 133.3333%
+  square: 100%
+  tall-wide: 66.66667%
+  wide: 56.25%
+  short-wide: 33.3333%
 breakpoint : 
   xs : 0
   s  : 375px


### PR DESCRIPTION
Card object fit was not working in the wild - using 'correct' image sizes created illusion it was working correctly. This fixes the issue. 

- absolutely position object-fit image
- test xbrowser - did not include polyfill in branch
- add image ratio sizes to tokens
- changed default image to square 800x800 image for testing
- add raw object-fit polyfill to cards grid sink page

To test:

1) Go to `/sink-pages/components/card-grids.html`
2) Make sure 800x800 image text looks the same as the raw image from `/images/components/container/800x800.png` (it is not stretched)
3) Open page on ie11 - make sure images all look correct - not warped or stretched

Note - will not work with captions, but captions not intended in card

Will require refactoring on .org - will request ticket