### PR TITLE
Feature/#336 ie11 radio field label wrapping

### DIFF
--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -457,7 +457,7 @@ $spirit-checkbox-group-label-color:       $spirit-text-color-primary;
 $spirit-checkbox-group-label-font-family: $spirit-checkbox-label-font-family;
 $spirit-checkbox-group-label-font-size:   $spirit-checkbox-label-font-size;
 $spirit-checkbox-group-label-margin:      $spirit-space-stack-2-x;
-$spirit-checkbox-group-label-max-width:   100%; // Fix overflow issue on mobile
+$spirit-checkbox-group-label-max-width:   100%; // Fix overflow issue on ie11
 $spirit-checkbox-group-max-width:         $spirit-form-element-max-width;
 
 .spirit-form__checkbox-group {

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -457,7 +457,7 @@ $spirit-checkbox-group-label-color:       $spirit-text-color-primary;
 $spirit-checkbox-group-label-font-family: $spirit-checkbox-label-font-family;
 $spirit-checkbox-group-label-font-size:   $spirit-checkbox-label-font-size;
 $spirit-checkbox-group-label-margin:      $spirit-space-stack-2-x;
-$spirit-checkbox-group-label-max-width:   $spirit-form-element-max-width;
+$spirit-checkbox-group-label-max-width:   100%; // Fix overflow issue on mobile
 $spirit-checkbox-group-max-width:         $spirit-form-element-max-width;
 
 .spirit-form__checkbox-group {

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -303,7 +303,7 @@ $spirit-checkbox-checkmark-size:            $spirit-size-icon-xs;
 $spirit-checkbox-margin:                    $spirit-space-stack-2-x;
 $spirit-checkbox-size:                      18px;
 $spirit-checkbox-grid-margin:               0 $spirit-space-generic-3-x $spirit-space-generic-2-x 0;
-$spirit-checkbox-max-width:                 $spirit-form-element-max-width;
+$spirit-checkbox-max-width:                 $spirit-form-element-max-width-100; // Fix overflow issue on ie11
 $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
 
 .spirit-form__checkbox {
@@ -312,7 +312,7 @@ $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
   display: block;
   font-size: 0;
   margin: $spirit-checkbox-margin;
-  max-width: $spirit-form-element-max-width-100; // Fix overflow issue on ie11
+  max-width: $spirit-checkbox-max-width;
   position: relative;
 
   .spirit-form__field-group--horizontal & {
@@ -504,7 +504,7 @@ $spirit-radio-fill-size:                8px;
 $spirit-radio-margin:                   $spirit-space-stack-2-x;
 $spirit-radio-size:                     18px;
 $spirit-radio-grid-margin:              0 $spirit-space-generic-3-x $spirit-space-generic-2-x 0;
-$spirit-radio-max-width:                $spirit-form-element-max-width;
+$spirit-radio-max-width:                $spirit-form-element-max-width-100; // Fix overflow issue on ie11
 $spirit-radio-label-space:              $spirit-space-generic-1-x;
 
 .spirit-form__radio {
@@ -512,7 +512,7 @@ $spirit-radio-label-space:              $spirit-space-generic-1-x;
   @include spirit-typography-reset;
   display: block;
   margin: $spirit-radio-margin;
-  max-width: $spirit-form-element-max-width-100; // Fix overflow issue on ie11;
+  max-width: $spirit-radio-max-width;
   position: relative;
 
   .spirit-form__field-group--horizontal & {

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -39,6 +39,7 @@ $spirit-form-element-height:                48px;
 
 // max-width
 $spirit-form-element-max-width:             none;
+$spirit-form-element-max-width-100:         100%;
 
 // space
 $spirit-form-element-padding:               10px 12px;
@@ -311,7 +312,7 @@ $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
   display: block;
   font-size: 0;
   margin: $spirit-checkbox-margin;
-  max-width: $spirit-checkbox-max-width;
+  max-width: $spirit-form-element-max-width-100; // Fix overflow issue on ie11
   position: relative;
 
   .spirit-form__field-group--horizontal & {
@@ -457,7 +458,7 @@ $spirit-checkbox-group-label-color:       $spirit-text-color-primary;
 $spirit-checkbox-group-label-font-family: $spirit-checkbox-label-font-family;
 $spirit-checkbox-group-label-font-size:   $spirit-checkbox-label-font-size;
 $spirit-checkbox-group-label-margin:      $spirit-space-stack-2-x;
-$spirit-checkbox-group-label-max-width:   100%; // Fix overflow issue on ie11
+$spirit-checkbox-group-label-max-width:   $spirit-form-element-max-width-100; // Fix overflow issue on ie11
 $spirit-checkbox-group-max-width:         $spirit-form-element-max-width;
 
 .spirit-form__checkbox-group {
@@ -511,7 +512,7 @@ $spirit-radio-label-space:              $spirit-space-generic-1-x;
   @include spirit-typography-reset;
   display: block;
   margin: $spirit-radio-margin;
-  max-width: $spirit-radio-max-width;
+  max-width: $spirit-form-element-max-width-100; // Fix overflow issue on ie11;
   position: relative;
 
   .spirit-form__field-group--horizontal & {

--- a/library/docs/sink-pages/components/forms.njk
+++ b/library/docs/sink-pages/components/forms.njk
@@ -452,6 +452,13 @@
         {{ library.form_checkbox(label="Option 3, Disabled", disabled=true) }}
     {% endcall %}
 
+    <h5 class="hostile-sink-reset">Group Stacked Label Content Resilience</h5>
+    {% call library.form_checkbox_group(label="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet deleniti quos molestiae placeat eaque in sunt corporis vel excepturi assumenda odit est rerum, debitis similique impedit alias quas ab. Cumque? .", required=true) %}
+        {{ library.form_checkbox(label="Option 1") }}
+        {{ library.form_checkbox(label="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Amet deleniti quos molestiae placeat eaque in sunt corporis vel excepturi assumenda odit est rerum, debitis similique impedit alias quas ab. ") }}
+        {{ library.form_checkbox(label="Option 3, Disabled", disabled=true) }}
+    {% endcall %}
+
     <h5 class="hostile-sink-reset">Group Horizontal</h5>
     {% call library.form_field_group(horizontal=true) %}
       {% call library.form_checkbox_group(label="What is your connection to type 1 diabetes?", required=true) %}


### PR DESCRIPTION
Give checkbox group label a max width of 100% to not allow overflow on ie11