### PR TITLE
feature/button-spinner-animation-fix

### DIFF
--- a/library/components/icon/icon.scss
+++ b/library/components/icon/icon.scss
@@ -31,6 +31,7 @@
 @keyframes spirit-icon-spinner-animation {
   100% {
     transform: rotate(360deg);
+    transform-origin: center;
   }
 }
 
@@ -38,6 +39,7 @@
   100%,
   0% {
     stroke: currentColor;
+    transform-origin: center;
   }
 
   40% {
@@ -58,6 +60,7 @@
   0% {
     stroke-dasharray: 1, 200;
     stroke-dashoffset: 0;
+    transform-origin: center;
   }
 
   50% {


### PR DESCRIPTION
Add transform origin to icon spinner - fix issue on .org and make animations generally more stable. 