### PR TITLE
Feature/#371 refine form grid

### DIFF
--- a/doc-site/docs/components/forms.njk
+++ b/doc-site/docs/components/forms.njk
@@ -587,6 +587,7 @@
 
   {% endfilter %}
   {% set form_grid_example %}
+      {% call library.form() %}
         {% call library.form_fieldset() %}
             {{ library.form_legend(text="Contributor") }}
             <div class="spirit-row">
@@ -749,6 +750,7 @@
               </div>
             </div>
         {% endcall %}
+      {% endcall %}
   {% endset %}
 
   {{ esds_doc.code_example_pair(
@@ -762,6 +764,21 @@
       Use the standard grid to lay out forms with multiple inputs per line.
   {% endfilter %}
   {% set form_grid_example %}
+      {% call library.form() %}
+        <div class="spirit-row">
+            <div class="spirit-col-md-6">
+              {% call library.form_field_group() %}
+                  {{ library.form_label(text="First Name", for="full-form-first-name") }}
+                  {{ library.form_input(id="full-form-first-name") }}
+              {% endcall %}
+            </div>
+            <div class="spirit-col-md-6">
+              {% call library.form_field_group() %}
+                  {{ library.form_label(text="Last Name", for="full-form-last-name") }}
+                  {{ library.form_input(id="full-form-last-name") }}
+              {% endcall %}
+            </div>
+          </div>
         {% call library.form_fieldset() %}
             {{ library.form_legend(text="Billing Address") }}
             {% call library.form_field_group() %}
@@ -809,6 +826,7 @@
               </div>
             </div>
         {% endcall %}
+      {% endcall %}
   {% endset %}
 
   {{ esds_doc.code_example_pair(

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -74,6 +74,21 @@ $spirit-form-element-grid-space:            0 $spirit-space-generic-2-x $spirit-
 // Form
 .spirit-form {
   @include spirit-typography-reset;
+
+  // Form Grid Styles
+  @media (min-width: $spirit-breakpoint-grid) {
+
+    .spirit-row {
+      margin-left: -($spirit-grid-gutter-width / 2);
+      margin-right: -($spirit-grid-gutter-width / 2);
+    }
+
+    .spirit-row > .spirit-col,
+    .spirit-row > [class*='spirit-col-'] {
+      padding-left: ($spirit-grid-gutter-width / 2);
+      padding-right: ($spirit-grid-gutter-width / 2);
+    }
+  }
 }
 
 // Field Group
@@ -306,9 +321,11 @@ $spirit-required-field-indicator-color: $spirit-form-element-error-color;
   font-weight: $spirit-font-weight-regular;
 }
 
+// sass-lint:disable class-name-format
 .spirit-form__label--accessibly_hidden {
   @include spirit-accessibly-hidden;
 }
+// sass-lint:enable class-name-format
 
 // <input[type='checkbox']/>
 $spirit-checkbox-label-color:               $spirit-text-color-secondary;

--- a/library/docs/sink-pages/components/forms.njk
+++ b/library/docs/sink-pages/components/forms.njk
@@ -581,68 +581,72 @@
 
     <h2 class="hostile-sink-reset">Fieldset &amp; Legend</h2>
     <h5 class="hostile-sink-reset">Fieldset, hidden legend</h5>
-    {% call library.form_fieldset() %}
-        {{ library.form_legend(text="Contact Info", hidden=true) }}
-        <div class="spirit-row">
-            <div class="spirit-col-md-6">
-              {% call library.form_field_group() %}
-                {{ library.form_label(text="First Name", for="contact-info-first-name") }}
-                {{ library.form_input(id="contact-info-first-name") }}
-              {% endcall %}
-            </div>
-            <div class="spirit-col-md-6">
-              {% call library.form_field_group() %}
-                {{ library.form_label(text="Last Name", for="contact-info-last-name") }}
-                {{ library.form_input(id="contact-info-last-name") }}
-              {% endcall %}
-            </div>
-        </div>
+    {% call library.form() %}
+      {% call library.form_fieldset() %}
+          {{ library.form_legend(text="Contact Info", hidden=true) }}
+          <div class="spirit-row">
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="First Name", for="contact-info-first-name") }}
+                  {{ library.form_input(id="contact-info-first-name") }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="Last Name", for="contact-info-last-name") }}
+                  {{ library.form_input(id="contact-info-last-name") }}
+                {% endcall %}
+              </div>
+          </div>
 
-        {% call library.form_field_group() %}
-            {{ library.form_label(text="Email", for="contact-info-email") }}
-            {{ library.form_input(id="contact-info-email") }}
-        {% endcall %}
+          {% call library.form_field_group() %}
+              {{ library.form_label(text="Email", for="contact-info-email") }}
+              {{ library.form_input(id="contact-info-email") }}
+          {% endcall %}
+      {% endcall %}
     {% endcall %}
 
 
 
     <h5 class="hostile-sink-reset">Fieldset with Legend</h5>
-    {% call library.form_fieldset() %}
-        {{ library.form_legend(text="Payment Info") }}
-        {% call library.form_field_group() %}
-            {{ library.form_label(text="Credit Card Number", for="payment-info-cc-number") }}
-            {{ library.form_input(id="payment-info-cc-number") }}
-        {% endcall %}
-        <div class="spirit-row">
-            <div class="spirit-col-md-4">
-              {% call library.form_field_group() %}
-                  {{ library.form_label(text="Payment Type", for="payment-info-type") }}
-                  {{ library.form_select(id="payment-info-type", 
-                    options=[
-                      {
-                          text: "Credit Card",
-                          value: "credit"
-                      },
-                      {
-                          text: "Bank Account",
-                          value: "bank_account"
-                      }
-                  ]) }}
-              {% endcall %}
-            </div>
-            <div class="spirit-col-sm-6 spirit-col-md-4">
-              {% call library.form_field_group() %}
-                  {{ library.form_label(text="Expiration", for="payment-info-cc-expiration") }}
-                  {{ library.form_input(id="payment-info-cc-expiration", type="date", placeholder="MM/YY", showMask=true) }}
-              {% endcall %}
-            </div>
-            <div class="spirit-col-sm-6 spirit-col-md-4">
-              {% call library.form_field_group() %}
-                  {{ library.form_label(text="CVV", for="payment-info-cvv") }}
-                  {{ library.form_input(id="payment-info-cvv") }}
-              {% endcall %}
-            </div>
-        </div>
+    {% call library.form() %}
+      {% call library.form_fieldset() %}
+          {{ library.form_legend(text="Payment Info") }}
+          {% call library.form_field_group() %}
+              {{ library.form_label(text="Credit Card Number", for="payment-info-cc-number") }}
+              {{ library.form_input(id="payment-info-cc-number") }}
+          {% endcall %}
+          <div class="spirit-row">
+              <div class="spirit-col-md-4">
+                {% call library.form_field_group() %}
+                    {{ library.form_label(text="Payment Type", for="payment-info-type") }}
+                    {{ library.form_select(id="payment-info-type", 
+                      options=[
+                        {
+                            text: "Credit Card",
+                            value: "credit"
+                        },
+                        {
+                            text: "Bank Account",
+                            value: "bank_account"
+                        }
+                    ]) }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-sm-6 spirit-col-md-4">
+                {% call library.form_field_group() %}
+                    {{ library.form_label(text="Expiration", for="payment-info-cc-expiration") }}
+                    {{ library.form_input(id="payment-info-cc-expiration", type="date", placeholder="MM/YY", showMask=true) }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-sm-6 spirit-col-md-4">
+                {% call library.form_field_group() %}
+                    {{ library.form_label(text="CVV", for="payment-info-cvv") }}
+                    {{ library.form_input(id="payment-info-cvv") }}
+                {% endcall %}
+              </div>
+          </div>
+      {% endcall %}
     {% endcall %}
 
 


### PR DESCRIPTION
- Add styles to .spirit-row and [class*='spirit-col-'] when nested within a <form> component that maintains 16px gutter
- add `<form>` component to library and doc site sink pages for continuity when using the grid

In library:
See: `/sink-pages/components/forms.html` -- grid items towards bottom of sink

In doc site (after library compiled):
-- npm run unlink-local-library
-- npm run link-local-library
-- gulp
See: `/components/forms.html#form-grid`