### PR TITLE
feature/#387-update-card-image-ratio:

### DIFF
--- a/doc-site/docs/getting-started.njk
+++ b/doc-site/docs/getting-started.njk
@@ -160,17 +160,17 @@
 
     ##### Component Scripts
     {% endfilter %}
-    {{ esds_doc.code_snippet(source='<script src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.min.js" rel="stylesheet"></script>') }}
+    {{ esds_doc.code_snippet(source='<script type="text/javascript" src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.min.js"></script>') }}
     {% filter markdown %}
 
     ##### Spirit Dependencies - Spirit dependencies (i.e. svg4everybody)
     {% endfilter %}
-    {{ esds_doc.code_snippet(source='<script src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.dependencies.min.js" rel="stylesheet"></script>') }}
+    {{ esds_doc.code_snippet(source='<script type="text/javascript" src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.dependencies.min.js"></script>') }}
     {% filter markdown %}
 
     ##### Spirit Bundle - Component scripts, bundle only scripts (i.e. calls to dependencies), and spirit dependencies.
     {% endfilter %}
-    {{ esds_doc.code_snippet(source='<script src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.bundle.min.js" rel="stylesheet"></script>') }}
+    {{ esds_doc.code_snippet(source='<script type="text/javascript" src="https://cdn.jdrf.design/v/' + spirit_project_data.version + '/scripts/dependencies/spirit.bundle.min.js"></script>') }}
     {% filter markdown %}
 
     Use these scripts as needed and at the direction of the project.

--- a/library/components/card/card.scss
+++ b/library/components/card/card.scss
@@ -130,7 +130,7 @@ $spirit-card-list-image-size-sm: 72px;
   }
 
   .spirit-image__image-wrap {
-    padding-top: $spirit-ratio-tall-wide;
+    padding-top: $spirit-ratio-wide;
   }
 
   @media screen and (min-width: $spirit-breakpoint-m) {


### PR DESCRIPTION
- update card image ratio
- update script output on docsite (gettin started text)

1) Make sure cards images are correct 16:9 ratio
- Open library, pull branch, and run `gulp`
- See: `/sink-pages/components/cards.html`
- See: `/components/card-grids.html`

2) Make sure text is correct in Getting Started on doc site for script import
- Open doc site, pull branch, and gun `gulp`
- See: `/getting-started.html#external-dependencies`
- Look at the script dependencies, should no longer reference 'stylesheet' and now have "type='javascript'" (i.e. ) `<script type="text/javascript" src="https://cdn.jdrf.design/v/1.0.0/scripts/dependencies/spirit.min.js"></script>`