### PR TITLE
change checkmark fill color to meet accessibility standards

### DIFF
--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -350,7 +350,9 @@ $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
 
 .spirit-form__checkbox {
   @include spirit-box-sizing;
-  @include spirit-typography-reset;
+  @include spirit-typography-reset(
+    $color: $spirit-checkbox-checkmark-fill-color
+  );
   display: block;
   font-size: 0;
   margin: $spirit-checkbox-margin;


### PR DESCRIPTION
This MR corresponds with the following ticket in JIRA: https://jdrf.atlassian.net/browse/CMEG-561

To test: 
In branch and in library:
- `grunt`
- go to `/sink-pages/components/forms.html`
- view section with checkboxes - icons should now be white when blue background is present

To test in doc-site:
- be in this branch
- in doc-site directory
- `npm run link-local-library`
- `gulp`
- view `/components/forms.html#checkbox`