### PR TITLE
update font weights|sizes for labels add line height token

### DIFF
--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -42,7 +42,7 @@ $spirit-form-element-max-width:             none;
 $spirit-form-element-max-width-100:         100%;
 
 // line height
-$spirit-form-label-line-height:             1.3;
+$spirit-form-label-line-height:             1.25;
 
 // space
 $spirit-form-element-padding:               10px 12px;

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -41,6 +41,9 @@ $spirit-form-element-height:                48px;
 $spirit-form-element-max-width:             none;
 $spirit-form-element-max-width-100:         100%;
 
+// line height
+$spirit-form-label-line-height:             1.3;
+
 // space
 $spirit-form-element-padding:               10px 12px;
 $spirit-form-element-stack:                 $spirit-space-stack-half-x;
@@ -285,7 +288,7 @@ $spirit-textarea-placeholder-color:   $spirit-form-element-placeholder-color;
 $spirit-label-color:        $spirit-form-label-color;
 $spirit-label-font-family:  $spirit-form-font-family;
 $spirit-label-font-size:    $spirit-font-size-m;
-$spirit-label-line-height:  $spirit-font-line-height-heading-level-3-normal;
+$spirit-label-line-height:  $spirit-form-label-line-height;
 $spirit-label-margin:       $spirit-form-element-stack;
 $spirit-label-max-width:    $spirit-form-element-max-width;
 

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -182,7 +182,7 @@ $spirit-text-input-padding:           $spirit-form-element-padding;
   @include spirit-typography-reset(
     $color: $spirit-text-input-color,
     $font-size: $spirit-text-input-font-size,
-    $font-weight: $spirit-font-weight-medium
+    $font-weight: $spirit-font-weight-regular
   );
   background-color: $spirit-text-input-background-color;
   border: $spirit-text-input-border;
@@ -242,7 +242,7 @@ $spirit-textarea-placeholder-color:   $spirit-form-element-placeholder-color;
   @include spirit-typography-reset(
     $color: $spirit-textarea-color,
     $font-size: $spirit-textarea-font-size,
-    $font-weight: $spirit-font-weight-medium
+    $font-weight: $spirit-font-weight-regular
   );
   background-color: $spirit-textarea-background-color;
   border: $spirit-textarea-border;
@@ -284,7 +284,8 @@ $spirit-textarea-placeholder-color:   $spirit-form-element-placeholder-color;
 // <label>
 $spirit-label-color:        $spirit-form-label-color;
 $spirit-label-font-family:  $spirit-form-font-family;
-$spirit-label-font-size:    $spirit-font-size-s;
+$spirit-label-font-size:    $spirit-font-size-m;
+$spirit-label-line-height:  $spirit-font-line-height-heading-level-3-normal;
 $spirit-label-margin:       $spirit-form-element-stack;
 $spirit-label-max-width:    $spirit-form-element-max-width;
 
@@ -293,7 +294,8 @@ $spirit-label-max-width:    $spirit-form-element-max-width;
   @include spirit-typography-reset(
     $color: $spirit-label-color,
     $font-size: $spirit-label-font-size,
-    $font-weight: $spirit-font-weight-semibold
+    $font-weight: $spirit-font-weight-medium,
+    $line-height: $spirit-label-line-height
   );
   display: block;
   margin: $spirit-label-margin;


### PR DESCRIPTION
This MR corresponds with the following ticket in JIRA: https://jdrf.atlassian.net/browse/CMEG-563

To test:
In branch and in the library:

grunt
go to `/sink-pages/components/forms.html`
view section with input|textareas - font for labels should be as follows:
- weight: 500
- size: 16px
- line-height: 1.3/20px

view section with input|textareas - font should be as follows:
- weight: 400

To test in doc-site:

be in this branch
in doc-site directory
npm run link-local-library
gulp
view `/components/forms.html#input`