### PR TITLE
update button label font weight

### DIFF
--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -39,7 +39,7 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   font-family: $spirit-font-family-sans-serif;
   font-size: $spirit-font-size-m;
   font-style: normal;
-  font-weight: $spirit-font-weight-bold;
+  font-weight: $spirit-font-weight-semibold;
   letter-spacing: $spirit-button-font-letter-spacing-125;
   line-height: $spirit-font-line-height-controls;
   padding: $spirit-space-inset-squish-4-x;


### PR DESCRIPTION
This MR corresponds with the following ticket in JIRA: https://jdrf.atlassian.net/browse/CMEG-562

**To test:**
In branch and in the library:

grunt
go to `/sink-pages/components/buttons.html` and `/sink-pages/components/button-groups.html`
font-weight for buttons should be as follows:

- weight: 600 (semibold)

**To test in doc-site:**
be in this branch
in doc-site directory
npm run link-local-library
gulp
view `/components/buttons.html`