### PR TITLE
Feature/dgst 12 add form password input doc

### DIFF
--- a/doc-site/docs/components/forms.njk
+++ b/doc-site/docs/components/forms.njk
@@ -9,7 +9,6 @@
 
 {% block page_shell_content %}
 
-
   {% filter markdown %}
       ## Input
       Use input to gather a short string of text or a number. Also known as a text box.
@@ -46,23 +45,14 @@
   }}
   {% filter markdown %}
 
-      * Use for a single word, number, or line of text. For longer text, use Text Area.
-      * Wrap in a Form Group to attach label, microcopy, required indicator, and more.
+    * Use for a single word, number, or line of text. For longer text, use Text Area.
+    * Wrap in a Form Group to attach label, microcopy, required indicator, and more.
 
-      ### Password Input with Toggle
-      For password inputs, use the password input with toggle to enable the user to show and hide passwords.
-      
-      The password toggle button depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.
-  {% endfilter %}
-
-  {{ esds_doc.code_example_pair( example=library.form_input(type="password", password_toggle=true, value="password") ) }}
-
-  {% filter markdown %}
-
-    ### Input Masks
+    ### Masks
 
     Masking depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.
     #### Date - mm/dd/yy
+
   {% endfilter %}
     {% set mask_example_1 %}
       {% call library.form_field_group() %}
@@ -107,17 +97,30 @@
   {% filter markdown %}
     <h4>Phone Number - input[type="text"]</h4>
   {% endfilter %}
-    {% set mask_example_4 %}
-      {% call library.form_field_group() %}
-        {{ library.form_label(text="Home Phone", required=true) }}
-        {{ library.form_input(type="text", showMask=true) }}
-      {% endcall %}
-    {% endset %}
 
-    {{ esds_doc.code_example_pair(
-      examples=[ { example: mask_example_4 } ]
-      )
-    }}
+  {% set mask_example_4 %}
+    {% call library.form_field_group() %}
+      {{ library.form_label(text="Home Phone", required=true) }}
+      {{ library.form_input(type="text", showMask=true) }}
+    {% endcall %}
+  {% endset %}
+
+  {{ esds_doc.code_example_pair(
+    examples=[ { example: mask_example_4 } ]
+    )
+  }}
+
+  {% filter markdown %}
+
+      ### With Password Toggle
+      For password inputs, use the password input with toggle to enable the user to show and hide passwords.
+
+      The password toggle button depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.
+  {% endfilter %}
+
+  {{ esds_doc.code_example_pair( example=library.form_input(type="password", password_toggle=true, value="password") ) }}
+
+
   {% filter markdown %}
 
       ## Text Area

--- a/doc-site/docs/components/forms.njk
+++ b/doc-site/docs/components/forms.njk
@@ -55,11 +55,7 @@
       The password toggle button depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.
   {% endfilter %}
 
- {{ esds_doc.code_example_pair(
-    examples=[ { example: library.form_input(type="password", password_toggle=true, value="password") } ],
-    code_snippet_source=(library.form_input(type="password", password_toggle=true, value="password"))
-    )
-  }}
+  {{ esds_doc.code_example_pair( example=library.form_input(type="password", password_toggle=true, value="password") ) }}
 
   {% filter markdown %}
 

--- a/doc-site/docs/components/forms.njk
+++ b/doc-site/docs/components/forms.njk
@@ -49,6 +49,20 @@
       * Use for a single word, number, or line of text. For longer text, use Text Area.
       * Wrap in a Form Group to attach label, microcopy, required indicator, and more.
 
+      ### Password Input with Toggle
+      For password inputs, use the password input with toggle to enable the user to show and hide passwords.
+      
+      The password toggle button depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.
+  {% endfilter %}
+
+ {{ esds_doc.code_example_pair(
+    examples=[ { example: library.form_input(type="password", password_toggle=true, value="password") } ],
+    code_snippet_source=(library.form_input(type="password", password_toggle=true, value="password"))
+    )
+  }}
+
+  {% filter markdown %}
+
     ### Input Masks
 
     Masking depends on Javascript. See [Getting Started for Developers](/getting-started.html#external-dependencies) for information on the necessary dependencies.

--- a/library/components/form/form.js
+++ b/library/components/form/form.js
@@ -17,13 +17,23 @@ class SpiritFormPasswordToggle {
     passwordToggleInputs.forEach(i => {
       const input = i.querySelector('input');
       const trigger = i.querySelector('a');
+
+      if ( 'Show' === trigger.textContent ) {
+        trigger.setAttribute('aria-pressed', 'false');
+      } else {
+        trigger.setAttribute('aria-pressed', 'true');
+      }
+
       trigger.addEventListener('click', e => {
+        e.preventDefault();
         if (input.type === 'text') {
           input.type = 'password';
           trigger.textContent = 'Show';
+          trigger.setAttribute('aria-pressed', 'false');
         } else {
           input.type = 'text';
           trigger.textContent = 'Hide';
+          trigger.setAttribute('aria-pressed', 'true');
         }
       });
     });

--- a/library/components/form/form.js
+++ b/library/components/form/form.js
@@ -18,7 +18,7 @@ class SpiritFormPasswordToggle {
       const input = i.querySelector('input');
       const trigger = i.querySelector('a');
 
-      if ( 'Show' === trigger.textContent ) {
+      if (trigger.innerText === 'Show') {
         trigger.setAttribute('aria-pressed', 'false');
       } else {
         trigger.setAttribute('aria-pressed', 'true');

--- a/library/components/form/form.njk
+++ b/library/components/form/form.njk
@@ -114,7 +114,7 @@
             {% else %}
                 {% set password_toggle_text = "Show" %}
             {% endif %}
-          {{ link(class="spirit-form__input-password-toggle", text=password_toggle_text, href="#") }}
+          {{ link(class="spirit-form__input-password-toggle", text=password_toggle_text, role="button") }}
         {% endif %}
     </div>
 {% endmacro %}

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -433,7 +433,6 @@ $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
     background-color: $spirit-disabled-color-foreground;
   }
 
-
   // Invalid state
   .spirit-form__checkbox-group--invalid &,
   .spirit-form__checkbox--invalid & {
@@ -499,7 +498,6 @@ $spirit-checkbox-label-space:               $spirit-space-generic-1-x;
     color: $spirit-disabled-color-foreground;
   }
 }
-
 
 // Checkbox Group
 // <label> for group of <input[type='checkbox']/>
@@ -840,7 +838,6 @@ $spirit-select-icon-size:                 $spirit-size-icon-s;
   }
 }
 
-
 // Microcopy
 $spirit-microcopy-text-color:   $spirit-form-element-text-color-secondary;
 $spirit-microcopy-font-family:  $spirit-form-font-family;
@@ -858,7 +855,6 @@ $spirit-microcopy-max-width:    $spirit-form-element-max-width;
   margin: $spirit-microcopy-margin;
   max-width: $spirit-form-element-max-width;
 }
-
 
 // Required Fields Key
 $spirit-required-key-text-color:    $spirit-form-element-text-color-secondary;
@@ -942,10 +938,6 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
   @include spirit-accessibly-hidden;
 }
 
-
-
-
-
 // Form Level Messages
 .spirit-form__message {
   @include spirit-box-sizing;
@@ -1005,6 +997,7 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
 
 .spirit-form__input-password-toggle {
   @include spirit-typography-reset($color: $spirit-text-color-link, $font-weight: $spirit-font-weight-bold);
+  cursor: pointer;
   position: absolute;
   right: $spirit-space-generic-2-x;
   text-decoration: none;

--- a/library/components/link/link.njk
+++ b/library/components/link/link.njk
@@ -3,7 +3,8 @@
   text='This is a link',
   href=false,
   target=false,
-  type=false
+  type=false,
+  role=false
 ) %}
-  <a class="spirit-link{{ ' ' + class if class }}" {{ 'href=' + href if href }} {{ 'type=' + type if type }} {{ 'target=' + target if target }}>{{text if text}}{{ caller() if caller }}</a>
+  <a class="spirit-link{{ ' ' + class if class }}" {{ 'href=' + href if href }} {{ 'type=' + type if type }} {{ 'target=' + target if target }} {{ 'role=' + role if role }}>{{text if text}}{{ caller() if caller }}</a>
 {% endmacro %}

--- a/library/components/link/link.njk
+++ b/library/components/link/link.njk
@@ -4,7 +4,15 @@
   href=false,
   target=false,
   type=false,
-  role=false
+  role
 ) %}
-  <a class="spirit-link{{ ' ' + class if class }}" {{ 'href=' + href if href }} {{ 'type=' + type if type }} {{ 'target=' + target if target }} {{ 'role=' + role if role }}>{{text if text}}{{ caller() if caller }}</a>
+  <a 
+    class="spirit-link{{ ' ' + class if class }}"
+    {% if href %} href="{{ href }}" {% endif %}
+    {% if type %} type="{{ type }}" {% endif %}
+    {% if target %} target="{{ target }}" {% endif %}
+    {% if role %} role="{{ role }}" {% endif %}>
+      {{text if text}}
+      {{ caller() if caller }}
+    </a>
 {% endmacro %}

--- a/library/docs/sink-pages/components/links.njk
+++ b/library/docs/sink-pages/components/links.njk
@@ -55,6 +55,9 @@
                 <h2 class="hostile-sink-reset">Link Active</h2>
                 <p class="hostile-sink-reset">{{ library.link(href="#", class="spirit-link--active") }}</p>
 
+                <h2 class="hostile-sink-reset">Link Role as Button</h2>
+                <p class="hostile-sink-reset">{{ library.link(role="button") }}</p>
+
                 <h2 class="hostile-sink-reset">Link Long</h2>
                 <p class="hostile-sink-reset">{{ library.link(text="this is an inline link that is very long for testing super duper long links for testing", href="#") }}</p>
 

--- a/library/docs/sink-pages/components/password-input-with-toggle.njk
+++ b/library/docs/sink-pages/components/password-input-with-toggle.njk
@@ -19,7 +19,7 @@
   <div class="forms-sink-wrapper">
 
     <h2 class="hostile-sink-reset">Default (password hidden)</h2>
-    {{ library.form_input(type="password", password_toggle=true) }}
+    {{ library.form_input(type="password", password_toggle=true, value="password") }}
 
     <h2 class="hostile-sink-reset">Password Visible By Default</h2>
     {{ library.form_input(type="password", password_toggle=true, password_toggle_visible=true) }}


### PR DESCRIPTION
This update has changes to both the library and the doc site

Library:
- update the link macro so it displays `"` correctly when used in the code example pairs on the doc site
- enable the use of `role` in the link macro for use on the doc site
- update the forms.js script for the password toggle to prevent default link action and `aria-clicked` attributes
- general code cleanup

Doc Site:
- Add content for password input with toggle 
- Add code example pair for password input with toggle

To view on doc site:
- pull branch
- in library directory run `gulp`
- switch to doc-site directory
- run `npm run link-local-library`
- run `gulp`
- go to `/components/forms.html#password-input-with-toggle` and review