### PR TITLE
feature/DGST-25-add-spirit-body-text-do-lft

### DIFF
--- a/library/components/long-form-text/long-form-text.scss
+++ b/library/components/long-form-text/long-form-text.scss
@@ -99,12 +99,14 @@ $spirit-long-form-text-ul-margin-bottom-lg: 18px;
   }
 
   p,
+  .spirit-body-text-l,
   .spirit-body-l {
     @include spirit-body-text-l;
     margin-bottom: $spirit-space-generic-2-x;
     margin-top: 0;
   }
 
+  .spirit-body-text-m,
   .spirit-body-m {
     @include spirit-body-text-m;
     margin-bottom: $spirit-space-generic-2-x;
@@ -112,6 +114,7 @@ $spirit-long-form-text-ul-margin-bottom-lg: 18px;
   }
 
   small,
+  .spirit-body-text-s,
   .spirit-body-s {
     @include spirit-body-text-s;
     margin-bottom: $spirit-space-generic-2-x;
@@ -194,7 +197,6 @@ $spirit-long-form-text-ul-margin-bottom-lg: 18px;
   blockquote p {
     @include spirit-h3;
   }
-
 
   blockquote {
     margin-bottom: $spirit-space-generic-4-x;
@@ -304,7 +306,7 @@ $spirit-long-form-text-ul-margin-bottom-lg: 18px;
   iframe img,
   object video,
   object img,
-  picture img, {
+  picture img {
     margin: 0;
     padding: 0;
 
@@ -421,7 +423,7 @@ $spirit-long-form-text-ul-margin-bottom-lg: 18px;
   }
 }
 
-// Enable body text modifier on container
+// Enable body text modifier on spirit-long-form-text container
 .spirit-long-form-text--l {
   p,
   li {

--- a/library/docs/sink-pages/components/long-form-text.njk
+++ b/library/docs/sink-pages/components/long-form-text.njk
@@ -82,6 +82,138 @@
         {% endfilter %}
         <div class="spirit-long-form-text">
             <h1>
+                Container default size
+            </h1>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h2>
+                You Can Help Turn Type One Into Type None
+            </h2>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h3>
+                You Can Help Turn Type One Into Type None
+            </h3>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h4>
+                You Can Help Turn Type One Into Type None
+            </h4>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h5>
+                You Can Help Turn Type One Into Type None
+            </h5>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h6>
+                You Can Help Turn Type One Into Type None
+            </h6>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                </li>
+                <li>List item 3</li>
+                <li>List item 4</li>
+            </ul>
+        </div>
+        <div class="spirit-long-form-text spirit-long-form-text--s">
+            <h1>
+                Container small size
+            </h1>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h2>
+                You Can Help Turn Type One Into Type None
+            </h2>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h3>
+                You Can Help Turn Type One Into Type None
+            </h3>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h4>
+                You Can Help Turn Type One Into Type None
+            </h4>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h5>
+                You Can Help Turn Type One Into Type None
+            </h5>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h6>
+                You Can Help Turn Type One Into Type None
+            </h6>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                </li>
+                <li>List item 3</li>
+                <li>List item 4</li>
+            </ul>
+        </div>
+        <div class="spirit-long-form-text spirit-long-form-text--m">
+            <h1>
+                Container medium size
+            </h1>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h2>
+                You Can Help Turn Type One Into Type None
+            </h2>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h3>
+                You Can Help Turn Type One Into Type None
+            </h3>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h4>
+                You Can Help Turn Type One Into Type None
+            </h4>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h5>
+                You Can Help Turn Type One Into Type None
+            </h5>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h6>
+                You Can Help Turn Type One Into Type None
+            </h6>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                </li>
+                <li>List item 3</li>
+                <li>List item 4</li>
+            </ul>
+        </div>
+        <div class="spirit-long-form-text spirit-long-form-text--l">
+            <h1>
+                Container medium size
+            </h1>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h2>
+                You Can Help Turn Type One Into Type None
+            </h2>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h3>
+                You Can Help Turn Type One Into Type None
+            </h3>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h4>
+                You Can Help Turn Type One Into Type None
+            </h4>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h5>
+                You Can Help Turn Type One Into Type None
+            </h5>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <h6>
+                You Can Help Turn Type One Into Type None
+            </h6>
+            <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
+            <ul>
+                <li>List item 1</li>
+                <li>List item 2 is very long so that it wraps onto the next line so that I can illustrate how this will look.
+                </li>
+                <li>List item 3</li>
+                <li>List item 4</li>
+            </ul>
+        </div>
+        <div class="spirit-long-form-text">
+            <h1>
                 You Can Help Turn Type One Into Type None
             </h1>
             <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>.</p>
@@ -131,26 +263,26 @@
             <p>Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin sed gravida enim. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. </p>
 
             {% filter markdown(true, "hostile-sink-reset") %}
-                ## Spirit Body L (default)
+                ## Spirit Body L (default) on selector
             {% endfilter %}
-            <p class="spirit-body-l">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+            <p class="spirit-body-text-l">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
 
-            <p class="spirit-body-l">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+            <p class="spirit-body-text-l">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
 
             {% filter markdown(true, "hostile-sink-reset") %}
-                ## Spirit Body M
+                ## Spirit Body M on selector
             {% endfilter %}
-            <p class="spirit-body-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+            <p class="spirit-body-text-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
 
-            <p class="spirit-body-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+            <p class="spirit-body-text-m">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
 
             {% filter markdown(true, "hostile-sink-reset") %}
-                ## Spirit Body S
+                ## Spirit Body S on selector
             {% endfilter %}
 
-            <p class="spirit-body-s">You can use the <code>spirit-body-s</code> class. Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. Quisque sit amet aliquet nulla. Fusce luctus purus gravida rutrum laoreet. Phasellus in ipsum nibh. Proin tellus lorem, convallis nec sodales id, feugiat non erat. Aenean viverra nisl quis dignissim fermentum. Aliquam porta augue bibendum arcu suscipit, ac porttitor arcu venenatis. Fusce luctus, magna vitae ultrices convallis, nunc leo aliquam orci, ac viverra nisl neque pretium dolor.</p>
+            <p class="spirit-body-text-s">You can use the <code>spirit-body-text-s</code> class. Donec quis ex tristique, venenatis justo nec, interdum ipsum. Proin facilisis eros sapien, eget scelerisque <code>est tempor</code> nec. Phasellus ex dui, blandit eget dictum sed, convallis in metus. Donec <a href="#">at urna leo</a>. Maecenas tempor felis et mattis viverra. Sed auctor ligula eu ex volutpat rhoncus. Quisque sit amet aliquet nulla. Fusce luctus purus gravida rutrum laoreet. Phasellus in ipsum nibh. Proin tellus lorem, convallis nec sodales id, feugiat non erat. Aenean viverra nisl quis dignissim fermentum. Aliquam porta augue bibendum arcu suscipit, ac porttitor arcu venenatis. Fusce luctus, magna vitae ultrices convallis, nunc leo aliquam orci, ac viverra nisl neque pretium dolor.</p>
 
-            <p class="spirit-body-s">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
+            <p class="spirit-body-text-s">Vestibulum non risus in mi efficitur viverra. Proin nec eleifend eros. Vivamus sollicitudin tellus at dolor finibus, quis ullamcorper felis semper. Phasellus nibh dui, facilisis at finibus vel, tincidunt id ante. Proin at eleifend ligula. Integer neque eros, mattis quis mauris pharetra, placerat laoreet nisi. Ut sit amet augue fermentum, vehicula nulla eget, eleifend ipsum. Nunc laoreet et urna quis fermentum. Nunc eget pellentesque odio. Morbi consequat, quam ac scelerisque pellentesque, erat mauris commodo mauris, at malesuada massa dolor nec risus. Pellentesque bibendum arcu ac sapien accumsan, sit amet fringilla nisl luctus. Suspendisse sem ipsum, semper id lacinia ac, auctor non massa. Etiam sed diam non turpis pellentesque bibendum at at purus.</p>
 
             {% filter markdown(true, "hostile-sink-reset") %}
                 ## Lists


### PR DESCRIPTION
Ticket: https://jdrf.atlassian.net/browse/DGST-25

Add new classnames to long form text
Replace classnames in library sink page
Add library items for long form text with modifier classes

To view changes:
- pull branch
- goto `/library`
- run `gulp`
- view `/components/long-form-text.html/`
- See `Container small size`, `Container medium size`, `Container large size` for container classes being used (class existed already, but no in library sink or doc site)
- See `Spirit Body L (default) on selector`, `Spirit Body M on selector`, `Spirit Body S on selector`- these new use the new classname, but the legacy class / style has not been removed from the css.

Recommend NEW ticket / MR for doc site updates pertaining to this task