### PR TITLE
Feature/dgst 28 icon button enhancements

### DIFF
--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -4,8 +4,8 @@
       disabled=false,
       text=false,
       iconName=false,
-      iconLabel=false,
-      iconPosition=false,
+      iconPosition,
+      iconDecorative=true,
       el="button",
       type=false,
       href=false,
@@ -14,35 +14,117 @@
       feedbackText=false,
       name=false,
       value=false,
-      fullwidth=false
+      fullwidth=false,
+      buttonTitle=false,
+      displayIcon
       ) %}
   {% if href %}
     {% set el = 'a' %}
   {% endif %}
+  {% if iconName and not text and not buttonTitle  %}
+    {% set iconDecorative = false %}
+  {% endif %}
+  {% if iconName %}
+    {% set displayIcon %}
+      {% if text and not iconPosition %}
+        {% set iconPosition = 'left' %}
+      {% endif %}
+      {% if iconPosition %}
+        {% set iconClass = 'spirit-icon--' + iconName + ' spirit-icon--' + iconPosition %}
+       {% else %}
+        {% set iconClass = 'spirit-icon--' + iconName %}
+      {% endif %}
+      {{ icon(name=iconName, class=iconClass, decorative=iconDecorative, label=iconName if not iconDecorative )}}
+    {% endset %}
+  {% endif %}
+
+
   {% if ( el === 'checkbox' ) or ( el === 'radio' ) %}
     <div class="spirit-button spirit-button--toggle{{ ' ' + class if class }}">
-      <input class="spirit-button__input spirit-button__{{ el }}" {{ 'type=' + el }} {{ 'name=' + name if name }} {{ 'id=' + id if id }} {{ 'value=' + value if value }} tabindex="-1"/>
-      <label {{ 'for=' + id if id }} class="spirit-button__inner{{ ' spirit-button__inner--has-icon' if icon and text}}" tabindex="0">
-        {% if iconName %}
-          {% if not iconLabel %}
-            {% set iconLabel = iconName %}
-          {% endif %}
-          {{ icon(name=iconName, label=iconLabel, class='spirit-icon--' + iconName, decorative=false)}}
+      <input 
+        class="spirit-button__input spirit-button__{{ el }}"
+        type="{{el}}"
+        {% if name %}
+          name="{{name}}"
         {% endif %}
-        {{ text if text }}
+        {% if id %}
+          id="{{id}}"
+        {% endif %}
+        {% if value %}
+          value="{{value}}"
+        {% endif %}
+        tabindex="-1"
+      />
+      <label 
+        {% if id %}
+          for="{{id}}"
+        {% endif %}
+        {% if buttonTitle and not text %}
+          aria-label="{{buttonTitle}}"
+        {% endif %}
+        class="spirit-button__inner"
+        {% if buttonTitle %}
+          title="{{buttonTitle}}"
+        {% endif %}
+        tabindex="0"
+      >
+        {% if displayIcon and ( iconPosition === "left" or not iconPosition ) %}
+          {{ displayIcon | safe }}
+        {% endif %}
+        {% if text %}
+          <span class="spirit-button__default-text">
+            {{ text }}
+          </span>
+        {% endif %}
+        {% if displayIcon and iconPosition === "right" %}
+          {{ displayIcon | safe }}
+        {% endif %}
       </label>
     </div>
   {% elif ( el === 'submit' or el === 'reset' ) %}
-    <input {{ 'id=' + id if id }} {{ 'type=' + el }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--is-icon' if icon and not text}}" value="{{text if text}}" {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} />
+    <input
+      {% if id %}
+        id="{{id}}"
+      {% endif %}
+      {% if type %}
+        type="{{type}}"
+      {% endif %}
+      class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--is-icon' if iconName and not text}}"
+      value="{{text if text}}"
+      {% if loader %}
+        data-loader="{{loader}}"
+      {% endif %}
+      {% if feedbackType %}
+        data-type="{{feedbackType}}"
+      {% endif %}
+    />
   {% elif el %}
     {# Using type variable for <button type="submit"> or <a type="button"> options #}
-    <{{el}} {{ 'id=' + id if id }} {{ 'type=' + type if type }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--has-icon' if icon and text}}{{ ' spirit-button--is-icon' if icon and not text}}" {{ 'href=' + href if href }} {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} {{ 'disabled' if disabled }}>
-      {% if iconName %}
-        {% if not iconLabel %}
-          {% set iconLabel = iconName %}
-        {% endif %}
-          {{ icon(name=iconName, label=iconLabel, class='spirit-icon--' + iconName, decorative=false)}}
+    <{{el}}
+      {% if id %}
+        id="{{id}}"
       {% endif %}
+      {% if type %}
+        type="{{type}}"
+      {% endif %}
+      {% if href %}
+        href="{{href}}"
+      {% endif %}
+      class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--is-icon' if icon and not text}}"
+      {% if loader %}
+        data-loader="{{loader}}"
+      {% endif %}
+      {% if feedbackType %}
+        data-type="{{feedbackType}}"
+      {% endif %}
+      {% if buttonTitle %}
+        title="{{buttonTitle}}"
+      {% endif %}
+      {% if buttonTitle and not text %}
+        aria-label="{{buttonTitle}}"
+      {% endif %}
+      {{ 'disabled' if disabled }}
+    >
       {% if loader %}
         {% if class and 'spirit-button--loading' in class %}
           {% set loaderHidden = 'false' %}
@@ -61,7 +143,7 @@
           <svg aria-label="Loading" role="img" class="spirit-icon--spinner" viewBox="25 25 50 50" xmlns="http://www.w3.org/2000/svg"><circle class="spirit-icon--spinner__path" cx="50" cy="50" r="20" stroke-width="4" stroke-miterlimit="10"/></svg>
         </span>
         {% if feedbackText %}
-          <span class="spirit-button__success-text" aria-hidden="{{feedbackTextHidden if feedbackTextHidden}}">
+          <span class="spirit-button__default-text spirit-button__success-text" aria-hidden="{{feedbackTextHidden if feedbackTextHidden}}">
             {{ feedbackText if feedbackText }}
           </span>
         {% else %}
@@ -70,11 +152,17 @@
           </span>
         {% endif %}
         <span class="spirit-button__default-text" aria-hidden="{{loaderTextHidden if loaderTextHidden}}">
+          {% if displayIcon and ( iconPosition === "left" or not iconPosition ) %}
+            {{ displayIcon | safe }}
+          {% endif %}
           {{ text if text }}
+          {% if displayIcon and iconPosition === "right" %}
+            {{ displayIcon | safe }}
+          {% endif %}
         </span>
       {% elif feedbackType and feedbackType === 'success' %}
         {% if feedbackText %}
-          <span class="spirit-button__success-text" aria-hidden="false">
+          <span class="spirit-button__default-text spirit-button__success-text" aria-hidden="false">
             {{ feedbackText if feedbackText }}
           </span>
         {% else %}
@@ -83,11 +171,23 @@
           </span>
         {% endif %}
         <span class="spirit-button__default-text" {{'aria-hidden=true' if feedbackType === 'success' }}>
+          {% if displayIcon and ( iconPosition === "left" or not iconPosition ) %}
+            {{ displayIcon | safe }}
+          {% endif %}
           {{ text if text }}
+          {% if displayIcon and iconPosition === "right" %}
+            {{ displayIcon | safe }}
+          {% endif %}
         </span>
-      {% else %}
-        {{ text if text }}  
+      {% elif text or displayIcon%}
+        {% if displayIcon and ( iconPosition === "left" or not iconPosition ) %}
+          {{ displayIcon | safe }}
+        {% endif %}
+        {{ text if text }}
+        {% if displayIcon and iconPosition === "right" %}
+          {{ displayIcon | safe }}
+        {% endif %}
       {% endif %}
-      </{{el}}>
+    </{{el}}>
   {% endif %}
 {% endmacro %}

--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -30,9 +30,9 @@
         {% set iconPosition = 'left' %}
       {% endif %}
       {% if iconPosition %}
-        {% set iconClass = 'spirit-icon--' + iconName + ' spirit-icon--' + iconPosition %}
+        {% set iconClass = 'spirit-icon--' + iconName + ' spirit-button__icon spirit-button__icon--' + iconPosition %}
        {% else %}
-        {% set iconClass = 'spirit-icon--' + iconName %}
+        {% set iconClass = 'spirit-icon--' + iconName + ' spirit-button__icon' %}
       {% endif %}
       {{ icon(name=iconName, class=iconClass, decorative=iconDecorative, label=iconName if not iconDecorative )}}
     {% endset %}

--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -5,6 +5,7 @@
       text=false,
       iconName=false,
       iconLabel=false,
+      iconPosition=false,
       el="button",
       type=false,
       href=false,
@@ -21,7 +22,7 @@
   {% if ( el === 'checkbox' ) or ( el === 'radio' ) %}
     <div class="spirit-button spirit-button--toggle{{ ' ' + class if class }}">
       <input class="spirit-button__input spirit-button__{{ el }}" {{ 'type=' + el }} {{ 'name=' + name if name }} {{ 'id=' + id if id }} {{ 'value=' + value if value }} tabindex="-1"/>
-      <label {{ 'for=' + id if id }} class="spirit-button__inner" tabindex="0">
+      <label {{ 'for=' + id if id }} class="spirit-button__inner{{ ' spirit-button__inner--has-icon' if icon and text}}" tabindex="0">
         {% if iconName %}
           {% if not iconLabel %}
             {% set iconLabel = iconName %}
@@ -35,7 +36,7 @@
     <input {{ 'id=' + id if id }} {{ 'type=' + el }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--is-icon' if icon and not text}}" value="{{text if text}}" {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} />
   {% elif el %}
     {# Using type variable for <button type="submit"> or <a type="button"> options #}
-    <{{el}} {{ 'id=' + id if id }} {{ 'type=' + type if type }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--is-icon' if icon and not text}}" {{ 'href=' + href if href }} {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} {{ 'disabled' if disabled }}>
+    <{{el}} {{ 'id=' + id if id }} {{ 'type=' + type if type }} class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--has-icon' if icon and text}}{{ ' spirit-button--is-icon' if icon and not text}}" {{ 'href=' + href if href }} {{ 'data-loader=' + loader if loader }} {{ 'data-type=' + feedbackType if feedbackType }} {{ 'disabled' if disabled }}>
       {% if iconName %}
         {% if not iconLabel %}
           {% set iconLabel = iconName %}

--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -143,7 +143,7 @@
           <svg aria-label="Loading" role="img" class="spirit-icon--spinner" viewBox="25 25 50 50" xmlns="http://www.w3.org/2000/svg"><circle class="spirit-icon--spinner__path" cx="50" cy="50" r="20" stroke-width="4" stroke-miterlimit="10"/></svg>
         </span>
         {% if feedbackText %}
-          <span class="spirit-button__default-text spirit-button__success-text" aria-hidden="{{feedbackTextHidden if feedbackTextHidden}}">
+          <span class="spirit-button__success-text" aria-hidden="{{feedbackTextHidden if feedbackTextHidden}}">
             {{ feedbackText if feedbackText }}
           </span>
         {% else %}
@@ -162,7 +162,7 @@
         </span>
       {% elif feedbackType and feedbackType === 'success' %}
         {% if feedbackText %}
-          <span class="spirit-button__default-text spirit-button__success-text" aria-hidden="false">
+          <span class="spirit-button__success-text" aria-hidden="false">
             {{ feedbackText if feedbackText }}
           </span>
         {% else %}

--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -31,7 +31,7 @@ $spirit-button-icon-margin-bottom-small: -2px;
 $spirit-button-icon-margin-top-small: -2px;
 
 // Is Icon Button
-$spirit-button-is-icon-width: 130px;
+$spirit-button-is-icon-min-width: 130px;
 $spirit-button-is-icon-padding-default: 12px;
 $spirit-button-is-icon-padding-xs: 6px;
 $spirit-button-is-icon-padding-s: 10px;
@@ -115,8 +115,8 @@ $spirit-button-is-icon-padding-l: 20px;
   }
 
   .spirit-button__default-text:not([aria-hidden='true']) {
-    .spirit-icon--left,
-    .spirit-icon--right {
+    .spirit-button__icon--left,
+    .spirit-button__icon--right {
       visibility: visible;
     }
   }
@@ -127,14 +127,6 @@ $spirit-button-is-icon-padding-l: 20px;
     margin-bottom: $spirit-button-icon-margin-bottom-default;
     margin-top: $spirit-button-icon-margin-top-default;
     width: $spirit-size-icon-m;
-  }
-
-  .spirit-icon--left {
-    margin-right: $spirit-space-generic-1-x;
-  }
-
-  .spirit-icon--right {
-    margin-left: $spirit-space-generic-1-x;
   }
 
   // Spirit Button on Brand
@@ -183,6 +175,14 @@ $spirit-button-is-icon-padding-l: 20px;
   }
 }
 
+.spirit-button__icon--left {
+  margin-right: $spirit-space-generic-1-x;
+}
+
+.spirit-button__icon--right {
+  margin-left: $spirit-space-generic-1-x;
+}
+
 .spirit-button__icon-contain {
   align-items: center;
   display: flex;
@@ -205,7 +205,7 @@ $spirit-button-is-icon-padding-l: 20px;
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;
-  min-width: $spirit-button-is-icon-width;
+  min-width: $spirit-button-is-icon-min-width;
 }
 
 // Spririt Button - Extra Small

--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -144,6 +144,30 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   }
 }
 
+// Has icon and with text
+.spirit-button--has-icon,
+.spirit-button__inner--has-icon {
+  display: inline-flex;
+  flex-flow: row nowrap;
+  align-items: center;
+
+  [class*='spirit-icon-'] {
+    height: $spirit-size-icon-m;
+    width: $spirit-size-icon-m;
+    margin-top: -5px;
+    margin-bottom: -3px;
+    flex: 0 0 $spirit-size-icon-m;
+  }
+
+  [class*='spirit-icon-']:first-child {
+    margin-right: $spirit-space-generic-1-x;
+  }
+
+  [class*='spirit-icon-']:last-child {
+    margin-left: $spirit-space-generic-1-x;
+  }
+}
+
 .spirit-button__icon-contain {
   align-items: center;
   display: flex;
@@ -158,9 +182,9 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   [class*='spirit-icon-'] {
     height: $spirit-size-icon-s;
     width: $spirit-size-icon-s;
+    margin: 0;
   }
 }
-
 
 // Has icon and no text
 .spirit-button--is-icon {
@@ -501,8 +525,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
     cursor: not-allowed;
   }
 }
-
-
 
 // Spririt Button - Icon Only
 .spirit-button--icon-only {

--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -24,22 +24,38 @@ $spirit-space-inset-squish-3-x-negative: -12px -24px !default;
 $spirit-space-inset-squish-4-x-negative: -16px -32px !default;
 $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
 
+// Icon Spacing
+$spirit-button-icon-margin-bottom-default: -3px;
+$spirit-button-icon-margin-top-default: -5px;
+$spirit-button-icon-margin-bottom-small: -2px;
+$spirit-button-icon-margin-top-small: -2px;
+
+// Is Icon Button
+$spirit-button-is-icon-width: 130px;
+$spirit-button-is-icon-padding-default: 12px;
+$spirit-button-is-icon-padding-xs: 6px;
+$spirit-button-is-icon-padding-s: 10px;
+$spirit-button-is-icon-padding-l: 20px;
+
 // Spririt Button - Default
 .spirit-button,
 .spirit-button__inner {
   @include spirit-box-sizing(border-box);
   // sass-lint:disable property-sort-order, no-vendor-prefixes
+  align-items: center;
   background-color: $spirit-interactive-color-primary;
   border: 0;
   border-radius: $spirit-border-radius-m;
   box-shadow: $spirit-elevation-shadow-blue-1, inset 0 0 0 $spirit-border-width-button $spirit-interactive-color-primary;
   color: $spirit-interactive-color-text-on-dark;
   cursor: pointer;
-  display: inline-block;
+  display: inline-flex;
+  flex-flow: row nowrap;
   font-family: $spirit-font-family-sans-serif;
   font-size: $spirit-font-size-m;
   font-style: normal;
   font-weight: $spirit-font-weight-semibold;
+  justify-content: center;
   letter-spacing: $spirit-button-font-letter-spacing-125;
   line-height: $spirit-font-line-height-controls;
   padding: $spirit-space-inset-squish-4-x;
@@ -98,6 +114,29 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
     }
   }
 
+  .spirit-button__default-text:not([aria-hidden='true']) {
+    .spirit-icon--left,
+    .spirit-icon--right {
+      visibility: visible;
+    }
+  }
+
+  [class*='spirit-icon-'] {
+    flex: 0 0 $spirit-size-icon-m;
+    height: $spirit-size-icon-m;
+    margin-bottom: $spirit-button-icon-margin-bottom-default;
+    margin-top: $spirit-button-icon-margin-top-default;
+    width: $spirit-size-icon-m;
+  }
+
+  .spirit-icon--left {
+    margin-right: $spirit-space-generic-1-x;
+  }
+
+  .spirit-icon--right {
+    margin-left: $spirit-space-generic-1-x;
+  }
+
   // Spirit Button on Brand
   .spirit-context--brand & {
     background-color: $spirit-interactive-color-on-dark;
@@ -144,30 +183,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   }
 }
 
-// Has icon and with text
-.spirit-button--has-icon,
-.spirit-button__inner--has-icon {
-  display: inline-flex;
-  flex-flow: row nowrap;
-  align-items: center;
-
-  [class*='spirit-icon-'] {
-    height: $spirit-size-icon-m;
-    width: $spirit-size-icon-m;
-    margin-top: -5px;
-    margin-bottom: -3px;
-    flex: 0 0 $spirit-size-icon-m;
-  }
-
-  [class*='spirit-icon-']:first-child {
-    margin-right: $spirit-space-generic-1-x;
-  }
-
-  [class*='spirit-icon-']:last-child {
-    margin-left: $spirit-space-generic-1-x;
-  }
-}
-
 .spirit-button__icon-contain {
   align-items: center;
   display: flex;
@@ -180,24 +195,17 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   width: 100%;
 
   [class*='spirit-icon-'] {
-    height: $spirit-size-icon-s;
-    width: $spirit-size-icon-s;
     margin: 0;
   }
 }
 
-// Has icon and no text
+// Has icon and no text - round button
 .spirit-button--is-icon {
   align-items: center;
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;
-  min-width: 130px;
-
-  [class*='spirit-icon-'] {
-    height: $spirit-size-icon-s;
-    width: $spirit-size-icon-s;
-  }
+  min-width: $spirit-button-is-icon-width;
 }
 
 // Spririt Button - Extra Small
@@ -213,11 +221,12 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
     padding: $spirit-space-inset-squish-2-x;
   }
 
-  .spirit-button__icon-contain {
-    [class*='spirit-icon-'] {
-      height: $spirit-size-icon-xs;
-      width: $spirit-size-icon-xs;
-    }
+  [class*='spirit-icon-'] {
+    flex: 0 0 $spirit-size-icon-s;
+    height: $spirit-size-icon-s;
+    margin-bottom: $spirit-button-icon-margin-bottom-small;
+    margin-top: $spirit-button-icon-margin-top-small;
+    width: $spirit-size-icon-s;
   }
 }
 
@@ -233,6 +242,14 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
     margin: $spirit-space-inset-squish-3-x-negative;
     padding: $spirit-space-inset-squish-3-x;
   }
+
+  [class*='spirit-icon-'] {
+    flex: 0 0 $spirit-size-icon-s;
+    height: $spirit-size-icon-s;
+    margin-bottom: $spirit-button-icon-margin-bottom-small;
+    margin-top: $spirit-button-icon-margin-top-small;
+    width: $spirit-size-icon-s;
+  }
 }
 
 // Spririt Button - Default ( breakpoint sizing ) 
@@ -247,14 +264,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
       line-height: $spirit-font-line-height-controls;
       margin: $spirit-space-inset-squish-3-x-negative;
       padding: $spirit-space-inset-squish-3-x;
-    }
-
-    .spirit-button__icon-contain,
-    &.spirit-button--is-icon {
-      [class*='spirit-icon-'] {
-        height: $spirit-size-icon-s;
-        width: $spirit-size-icon-s;
-      }
     }
   }
 }
@@ -272,14 +281,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
       margin: $spirit-space-inset-squish-4-x-negative;
       padding: $spirit-space-inset-squish-4-x;
     }
-
-    .spirit-button__icon-contain,
-    &.spirit-button--is-icon {
-      [class*='spirit-icon-'] {
-        height: $spirit-size-icon-s;
-        width: $spirit-size-icon-s;
-      }
-    }
   }
 }
 
@@ -294,14 +295,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
       line-height: $spirit-font-line-height-controls;
       margin: $spirit-space-inset-squish-4-x-negative;
       padding: $spirit-space-inset-squish-4-x;
-    }
-
-    .spirit-button__icon-contain,
-    &.spirit-button--is-icon {
-      [class*='spirit-icon-'] {
-        height: $spirit-size-icon-s;
-        width: $spirit-size-icon-s;
-      }
     }
   }
 }
@@ -332,14 +325,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
       margin: $spirit-space-inset-squish-6-x-negative;
       padding: $spirit-space-inset-squish-6-x;
     }
-
-    .spirit-button__icon-contain,
-    &.spirit-button--is-icon {
-      [class*='spirit-icon-'] {
-        height: $spirit-size-icon-s;
-        width: $spirit-size-icon-s;
-      }
-    }
   }
 }
 
@@ -352,14 +337,6 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
       line-height: $spirit-font-line-height-controls;
       margin: $spirit-space-inset-squish-6-x-negative;
       padding: $spirit-space-inset-squish-6-x;
-    }
-
-    .spirit-button__icon-contain,
-    &.spirit-button--is-icon {
-      [class*='spirit-icon-'] {
-        height: $spirit-size-icon-s;
-        width: $spirit-size-icon-s;
-      }
     }
   }
 }
@@ -479,6 +456,12 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
     box-shadow: none;
     transform: translateY(0);
   }
+
+  &:focus,
+  &.spirit-button--focus {
+    box-shadow: none;
+    transform: translateY(0);
+  }
 }
 
 .spirit-button__input {
@@ -526,40 +509,64 @@ $spirit-space-inset-squish-6-x-negative: -24px -48px !default;
   }
 }
 
-// Spririt Button - Icon Only
+// Spririt Button - Icon Only - standard button design
 .spirit-button--icon-only {
   border-radius: 100%;
   min-width: 0;
-  padding: $spirit-space-inset-1-x;
+  padding: $spirit-button-is-icon-padding-default;
 
   [class*='spirit-icon-'] {
-    height: $spirit-size-icon-l;
-    width: $spirit-size-icon-l;
+    margin: 0;
+  }
+
+  // Spririt Button - Extra Small
+  &.spirit-button--extra-small {
+    padding: $spirit-button-is-icon-padding-xs;
   }
 
   // Spririt Button - Small
   &.spirit-button--small {
-    [class*='spirit-icon-'] {
-      height: $spirit-size-icon-m;
-      width: $spirit-size-icon-m;
-    }
+    padding: $spirit-button-is-icon-padding-s;
+  }
+
+  // Spririt Button - Large
+  &.spirit-button--large {
+    padding: $spirit-button-is-icon-padding-l;
   }
 
   // Spririt Button - Default ( breakpoint sizing )
   &.spirit-button--default-md {
     @media screen and (min-width: $spirit-breakpoint-m) {
+      padding: $spirit-button-is-icon-padding-default;
+
       [class*='spirit-icon-'] {
-        height: $spirit-size-icon-l;
-        width: $spirit-size-icon-l;
+        flex: 0 0 $spirit-size-icon-m;
+        height: $spirit-size-icon-m;
+        width: $spirit-size-icon-m;
       }
     }
   }
 
   &.spirit-button--default-lg {
     @media screen and (min-width: $spirit-breakpoint-l) {
+      padding: $spirit-button-is-icon-padding-default;
+
       [class*='spirit-icon-'] {
-        height: $spirit-size-icon-l;
-        width: $spirit-size-icon-l;
+        flex: 0 0 $spirit-size-icon-m;
+        height: $spirit-size-icon-m;
+        width: $spirit-size-icon-m;
+      }
+    }
+  }
+
+  &.spirit-button--large-lg {
+    @media screen and (min-width: $spirit-breakpoint-l) {
+      padding: $spirit-button-is-icon-padding-l;
+
+      [class*='spirit-icon-'] {
+        flex: 0 0 $spirit-size-icon-m;
+        height: $spirit-size-icon-m;
+        width: $spirit-size-icon-m;
       }
     }
   }

--- a/library/components/button/button.scss
+++ b/library/components/button/button.scss
@@ -114,13 +114,6 @@ $spirit-button-is-icon-padding-l: 20px;
     }
   }
 
-  .spirit-button__default-text:not([aria-hidden='true']) {
-    .spirit-button__icon--left,
-    .spirit-button__icon--right {
-      visibility: visible;
-    }
-  }
-
   [class*='spirit-icon-'] {
     flex: 0 0 $spirit-size-icon-m;
     height: $spirit-size-icon-m;
@@ -172,6 +165,12 @@ $spirit-button-is-icon-padding-l: 20px;
 .spirit-button__default-text {
   .spirit-button__success-text[aria-hidden='false'] + & {
     display: none;
+  }
+
+  &:not([aria-hidden='true']) {
+    .spirit-button__icon {
+      visibility: visible;
+    }
   }
 }
 

--- a/library/components/button_group/button_group.scss
+++ b/library/components/button_group/button_group.scss
@@ -10,6 +10,12 @@
     flex: 0 1 auto;
     margin: 0;
     position: relative;
+
+    &:hover,
+    &:active,
+    &:focus {
+      z-index: 2;
+    }
   }
 
   .spirit-button:not(:first-child) {

--- a/library/docs/index.njk
+++ b/library/docs/index.njk
@@ -23,6 +23,9 @@
             <a href="/sink-pages/components/button-groups.html">Button Groups</a>
         </li>
         <li>
+            <a href="/sink-pages/components/button-icons.html">Button Icons</a>
+        </li>
+        <li>
             <a href="/sink-pages/components/images.html">Image</a>
         </li>
         <li>

--- a/library/docs/sink-pages/components/button-groups.njk
+++ b/library/docs/sink-pages/components/button-groups.njk
@@ -17,7 +17,7 @@
         {{ library.button(class="spirit-button--active", text="$30", el="radio", name="radio-group", id="option7", value="20") }}
     {% endcall %}
 
-    <h2 class="hostile-sink-reset">Button Groups Small</h2>
+    <h2 class="hostile-sink-reset">Button Groups Extra Small</h2>
     {% call library.button_group() %}
         {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10") }}
         {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}

--- a/library/docs/sink-pages/components/button-groups.njk
+++ b/library/docs/sink-pages/components/button-groups.njk
@@ -12,37 +12,37 @@
 
     <h2 class="hostile-sink-reset">Button Groups Button Settings</h2>
     {% call library.button_group() %}
-        {{ library.button(class="spirit-button--hover", text="$10", el="radio", name="radio-group", id="option2", value="10") }}
-        {{ library.button(class="spirit-button--focus", text="$20", el="radio", name="radio-group", id="option3", value="15") }}
-        {{ library.button(class="spirit-button--active", text="$30", el="radio", name="radio-group", id="option4", value="20") }}
+        {{ library.button(class="spirit-button--hover", text="$10", el="radio", name="radio-group", id="option5", value="10") }}
+        {{ library.button(class="spirit-button--focus", text="$20", el="radio", name="radio-group", id="option6", value="15") }}
+        {{ library.button(class="spirit-button--active", text="$30", el="radio", name="radio-group", id="option7", value="20") }}
     {% endcall %}
 
     <h2 class="hostile-sink-reset">Button Groups Small</h2>
     {% call library.button_group() %}
-        {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option2", value="10") }}
-        {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option3", value="15") }}
-        {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option4", value="20") }}
+        {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10") }}
+        {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}
+        {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20") }}
     {% endcall %}
     
     <h2 class="hostile-sink-reset">Button Groups Small</h2>
     {% call library.button_group() %}
-        {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option2", value="10") }}
-        {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option3", value="15") }}
-        {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option4", value="20") }}
+        {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10") }}
+        {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15") }}
+        {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20") }}
     {% endcall %}
 
     <h2 class="hostile-sink-reset">Button Groups Standard / Default</h2>
     {% call library.button_group() %}
-        {{ library.button(text="$10", el="radio", name="radio-group", id="option2", value="10") }}
-        {{ library.button(text="$20", el="radio", name="radio-group", id="option3", value="15") }}
-        {{ library.button(text="$30", el="radio", name="radio-group", id="option4", value="20") }}
+        {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10") }}
+        {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15") }}
+        {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20") }}
     {% endcall %}
 
     <h2 class="hostile-sink-reset">Button Groups Large</h2>
     {% call library.button_group() %}
-        {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option2", value="10") }}
-        {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option3", value="15") }}
-        {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option4", value="20") }}
+        {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10") }}
+        {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15") }}
+        {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20") }}
     {% endcall %}
 
 {% endblock body %}

--- a/library/docs/sink-pages/components/button-groups.njk
+++ b/library/docs/sink-pages/components/button-groups.njk
@@ -23,7 +23,7 @@
         {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}
         {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20") }}
     {% endcall %}
-    
+
     <h2 class="hostile-sink-reset">Button Groups Small</h2>
     {% call library.button_group() %}
         {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10") }}

--- a/library/docs/sink-pages/components/button-icons.njk
+++ b/library/docs/sink-pages/components/button-icons.njk
@@ -6,71 +6,495 @@
         {% endfilter %}
     {% endcall %}
 
-    {% set sample_icon_buttons %}
-        <h1 class="spirit-h4">Primary</h1>
-
-        <h2 class="spirit-h5">Large</h2>
-        <p>{{ library.button(class="spirit-button--large", text="Donate Today") }}</p>
-
-        <h2 class="spirit-h5">Large with Icon Left</h2>
-        <p>{{ library.button(class="spirit-button--large", text="Donate Today", iconName="camera") }}</p>
-
-        <h2 class="spirit-h5">Medium (Default)</h2>
-        <p>{{ library.button(text="Donate Today") }}</p>
-
-        <h2 class="spirit-h5">Medium (Default) with Icon Left</h2>
-        <p>{{ library.button(text="Donate Today", iconName="camera") }}</p>
-
-
-        <h2 class="spirit-h5">Variants MAY NEED INNER CONTAINER - INLINE FLEX BLOCK</h2>
+    {% call library.container(padding_bottom="none") %}
         <div class="spirit-long-form-text">
-        <p>Some links to compare - to have an inner div or not?</p>
+            <p>Related Sink Pages:</p>
             <ul>
-            
+                <li>
+                    <a href="/sink-pages/components/buttons.html">Buttons</a>
+                </li>
+                <li>
+                    <a href="/sink-pages/components/button-groups.html">Button Groups</a>
+                </li>
+            </ul>
+        </div>
+    {% endcall %}
+
+    {% set sample_icon_buttons %}
+
+        <div class="spirit-long-form-text">
+            <p>This sink page is to test new styles / updates for buttons with icons and resiliency.</p>
+            <h3 class="spirit-h6">Current issues questions to be resolved:</h3>
+            <ul>
+                <li><b>Note</b>: There is no 'upload' icon in library. Do we need to add?</li>
+                <li><b>Side note</b>: spirit heading classes ignored in long form text - like `spirit-h6`. May want to add ticket in backlog?</li>
+                <li>Removed `.spirit-button--has-icon` and `spirit-button__inner--has-icon` styles as now inherited directly from `spirit-button`</li>
+                <li>Removed explicit instances of `.spirit-icon` styles (sizing) as not inherited from `spirit-button`</li>
+                <li><b>Engineering decision</b>: to use span around 'text' or 'label' on all buttons?
+                    <ul>
+                        <li>Chose no inner span for 'text' as to maintain current markup as much as possible and avoid any potential 'breaking changes.'</li>
+                        <li>Potential issue with no span for text: centered text when text wraps. See below.</li>
+                    </ul>
+                </li>
+                <li>Buttons with only icon as text (like submit button - not round), set icon to same size as new update (was smaller). Need confirmation. </li>
+                <li>Button groups on dark - border not visible. Should update here? </li>
+                <li>Updated toggle buttons sink to use different IDs </li>
+            </ul>
+            <h3 class="spirit-h6">Some desgin system reference links:</h3>
+            <ul>
                 <li><a href="https://www.lightningdesignsystem.com/components/buttons/">Salesforce</a></li>
-                <li><a href="https://developer.microsoft.com/en-us/fabric#/components/button">Fabric</a></li>
                 <li><a href="https://opensource.adobe.com/spectrum-css/components/button-primary/">Adobe</a></li>
                 <li><a href="https://material.io/components/buttons/#">Material</a></li>
                 <li><a href="https://rei.github.io/rei-cedar-docs/components/buttons/">Cedar</a></li>
             </ul>
         </div>
 
+        <h2 class="spirit-h4">Primary</h2>
 
-        <p>{{ library.button(el="checkbox", text="Donate Today", iconName="camera") }}</p>
-        <p>{{ library.button(el="radio", text="Donate Today", iconName="camera") }}</p>
-        <p>{{ library.button(el="a", href="#", text="Donate Today", iconName="camera") }}</p>
+        <h3 class="spirit-h5">Large</h3>
+        <p>{{ library.button(class="spirit-button--large", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Medium (Default) with Icon Right</h2>
+        <h3 class="spirit-h5">Large with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--large", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Large with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--large", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default)</h3>
+        <p>{{ library.button(text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Left</h3>
         <p>{{ library.button(text="Donate Today", iconName="camera") }}</p>
 
-        <p>Should the next button be the same icon size as above or remain as `$spirit-size-icon-s`?</p>
-        {{ library.button(loader="true", feedbackType="true", text="Submit Donation") }}
+        <h3 class="spirit-h5">Medium (Default) with Icon Right</h3>
+        <p>{{ library.button(text="Donate Today", iconName="camera", iconPosition="right") }}</p>
 
-        {{ library.button(class="spirit-button--icon-only", iconName="chevron-right") }}
-
-         <h2 class="spirit-h5">Small</h2>
+        <h3 class="spirit-h5">Small</h3>
         <p>{{ library.button(class="spirit-button--small", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Extra Small</h2>
+        <h3 class="spirit-h5">Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Extra Small</h3>
         <p>{{ library.button(class="spirit-button--extra-small", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Full Width</h2>
+        <h3 class="spirit-h5">Extra Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--extra-small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Extra Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--extra-small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Full Width</h3>
         <p>{{ library.button(text="Donate Today", fullwidth="true") }}</p>
 
-        <h2 class="spirit-h5">Default to Large LG Breakpoint</h2>
+        <h3 class="spirit-h5">Full Width with Icon Left</h3>
+        <p>{{ library.button(text="Donate Today", fullwidth="true", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Full Width with Icon Right</h3>
+        <p>{{ library.button(text="Donate Today", fullwidth="true", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Default to Large LG Breakpoint</h3>
         <p>{{ library.button(class="spirit-button--large-lg", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Default to Large MD Breakpoint</h2>
+        <h3 class="spirit-h5">Default to Large LG Breakpoint with icon Left</h3>
+        <p>{{ library.button(class="spirit-button--large-lg", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Default to Large LG Breakpoint with icon Right</h3>
+        <p>{{ library.button(class="spirit-button--large-lg", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Default to Large MD Breakpoint</h3>
         <p>{{ library.button(class="spirit-button--large-md", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Small to Default LG Breakpoint</h2>
+        <h3 class="spirit-h5">Default to Large MD Breakpoint with icon Left</h3>
+        <p>{{ library.button(class="spirit-button--large-md", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Default to Large MD Breakpoint with icon Right</h3>
+        <p>{{ library.button(class="spirit-button--large-md", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Small to Default LG Breakpoint</h3>
         <p>{{ library.button(class="spirit-button--small spirit-button--default-lg", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Small to Default MD Breakpoint</h2>
+        <h3 class="spirit-h5">Small to Default LG Breakpoint with icon Left</h3>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-lg", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Small to Default LG Breakpoint with icon Right</h3>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-lg", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Small to Default MD Breakpoint</h3>
         <p>{{ library.button(class="spirit-button--small spirit-button--default-md", text="Donate Today") }}</p>
 
-        <h2 class="spirit-h5">Extra Small to Small MD Breakpoint to Default LG Breakpoint</h2>
+        <h3 class="spirit-h5">Small to Default MD Breakpoint with icon Left</h3>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-md", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Small to Default MD Breakpoint with icon Right</h3>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-md", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Extra Small to Small MD Breakpoint to Default LG Breakpoint</h3>
         <p>{{ library.button(class="spirit-button--extra-small spirit-button--small-md spirit-button--default-lg", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Extra Small to Small MD Breakpoint to Default LG Breakpoint with icon Left</h3>
+        <p>{{ library.button(class="spirit-button--extra-small spirit-button--small-md spirit-button--default-lg", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Extra Small to Small MD Breakpoint to Default LG Breakpoint with icon Right</h3>
+        <p>{{ library.button(class="spirit-button--extra-small spirit-button--small-md spirit-button--default-lg", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Left with text resiliency</h3>
+        <p>{{ library.button(text="This is a Long Text Block to Test Button Text Resiliency whe the Text Goes More Than One Line", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Right with text resiliency</h3>
+        <p>{{ library.button(text="This is a Long Text Block to Test Button Text Resiliency whe the Text Goes More Than One Line", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Icon Only Extra Small</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--extra-small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Small</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Medium</h3>
+        {{ library.button(class="spirit-button--icon-only ", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Large</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--large", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Small to Default MD</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--small spirit-button--default-md", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Small to Default LG</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--small spirit-button--default-lg", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Small to Default MD to Large LG</h3>
+        {{ library.button(class="spirit-button--icon-only spirit-button--small spirit-button--default-md spirit-button--large-lg", iconName="eye-off") }}
+
+        <h2 class="spirit-h4">Secondary</h2>
+
+        <h3 class="spirit-h5">Large</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--large", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Large with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--large", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Large with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--large", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default)</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Small</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--small", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Extra Small</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--extra-small", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Extra Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--extra-small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Extra Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--secondary spirit-button--extra-small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Full Width</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today", fullwidth="true") }}</p>
+
+        <h3 class="spirit-h5">Full Width with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today", fullwidth="true", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Full Width with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--secondary", text="Donate Today", fullwidth="true", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Icon Only Extra Small</h3>
+        {{ library.button(class="spirit-button--secondary spirit-button--icon-only spirit-button--extra-small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Small</h3>
+        {{ library.button(class="spirit-button--secondary spirit-button--icon-only spirit-button--small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Medium</h3>
+        {{ library.button(class="spirit-button--secondary spirit-button--icon-only ", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Large</h3>
+        {{ library.button(class="spirit-button--secondary spirit-button--icon-only spirit-button--large", iconName="eye-off") }}
+
+        <h2 class="spirit-h4">Minimal</h2>
+
+        <h3 class="spirit-h5">Large</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--large", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Large with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--large", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Large with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--large", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default)</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Medium (Default) with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Small</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--small", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Extra Small</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--extra-small", text="Donate Today") }}</p>
+
+        <h3 class="spirit-h5">Extra Small with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--extra-small", text="Donate Today", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Extra Small with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--minimal spirit-button--extra-small", text="Donate Today", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Full Width</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today", fullwidth="true") }}</p>
+
+        <h3 class="spirit-h5">Full Width with Icon Left</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today", fullwidth="true", iconName="camera") }}</p>
+
+        <h3 class="spirit-h5">Full Width with Icon Right</h3>
+        <p>{{ library.button(class="spirit-button--minimal", text="Donate Today", fullwidth="true", iconName="camera", iconPosition="right") }}</p>
+
+        <h3 class="spirit-h5">Icon Only Extra Small</h3>
+        {{ library.button(class="spirit-button--minimal spirit-button--icon-only spirit-button--extra-small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Small</h3>
+        {{ library.button(class="spirit-button--minimal spirit-button--icon-only spirit-button--small", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Medium</h3>
+        {{ library.button(class="spirit-button--minimal spirit-button--icon-only ", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Icon Only Large</h3>
+        {{ library.button(class="spirit-button--minimal spirit-button--icon-only spirit-button--large", iconName="eye-off") }}
+
+        <h2 class="spirit-h4">Button Groups</h2>
+
+        <h3 class="spirit-h5">Button Groups Extra Small</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10") }}
+            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}
+            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Extra Small Icon Left</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10", iconName="camera") }}
+            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15", iconName="camera") }}
+            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20", iconName="camera") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Extra Small Icon Right</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20", iconName="camera", iconPosition="right") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Extra Small Icon Only</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option12", value="10", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option13", value="15", iconName="camera", buttonTitle="$15") }}
+            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option14", value="20", iconName="camera", buttonTitle="$20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Small</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10") }}
+            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15") }}
+            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Small Icon Left</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10", iconName="camera") }}
+            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15", iconName="camera") }}
+            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20", iconName="camera") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Small Icon Right</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20", iconName="camera", iconPosition="right") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Small Icon Only</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option22", value="10", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option23", value="15", iconName="camera", buttonTitle="$15") }}
+            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option24", value="20", iconName="camera", buttonTitle="$20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Standard / Default</h3>
+        {% call library.button_group() %}
+            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10") }}
+            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15") }}
+            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Standard / Default Icon Left</h3>
+        {% call library.button_group() %}
+            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10", iconName="camera") }}
+            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15", iconName="camera") }}
+            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20", iconName="camera") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Standard / Default Icon Right</h3>
+        {% call library.button_group() %}
+            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10", iconName="camera", iconPosition="right") }}
+            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15", iconName="camera", iconPosition="right") }}
+            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20", iconName="camera", iconPosition="right") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Standard / Default Icon Only</h3>
+        {% call library.button_group() %}
+            {{ library.button(el="radio", name="radio-group", id="option32", value="10", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(el="radio", name="radio-group", id="option33", value="15", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(el="radio", name="radio-group", id="option34", value="20", iconName="camera", buttonTitle="$10") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Large</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10") }}
+            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15") }}
+            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Large Icon Left</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10", iconName="camera") }}
+            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15", iconName="camera") }}
+            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20", iconName="camera") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Large Icon Right</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15", iconName="camera", iconPosition="right") }}
+            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20", iconName="camera", iconPosition="right") }}
+        {% endcall %}
+
+        <h3 class="spirit-h5">Button Groups Large Icon Only</h3>
+        {% call library.button_group() %}
+            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option42", value="10", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option43", value="15", iconName="camera", buttonTitle="$10") }}
+            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option44", value="20", iconName="camera", buttonTitle="$10") }}
+        {% endcall %}
+
+        <h2 class="spirit-h4">Toggle Groups</h2>
+
+        <h3 class="spirit-h5">Default</h3>
+
+        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250") }}
+        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120") }}
+        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60") }}
+        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30") }}
+
+        <h3 class="spirit-h5">Default Icon Left</h3>
+
+        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera") }}
+        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera") }}
+        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera") }}
+        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera") }}
+
+        <h3 class="spirit-h5">Default Icon Right</h3>
+
+        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera", iconPosition="right") }}
+        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera", iconPosition="right") }}
+        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera", iconPosition="right") }}
+        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Default Icon Only</h3>
+
+        {{ library.button(el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera", buttonTitle="$250") }}
+        {{ library.button(el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera", buttonTitle="$120") }}
+        {{ library.button(el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera", buttonTitle="$60") }}
+        {{ library.button(el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera", buttonTitle="$30") }}
+
+        <h2 class="spirit-h4">Additional Testing Variants</h2>
+
+        <h3 class="spirit-h5">Submit Icon Only</h3>
+
+        {{ library.button(loader="true", feedbackType="true", text="Submit Donation") }}
+
+        <h3 class="spirit-h5">Submit - input type submit - cannot have icon</h3>
+        {{ library.button(text="Primary Button Submit", el="submit") }}
+
+        <h3 class="spirit-h5">Submit - input type button - Icon Left</h3>
+        {{ library.button(el="button", type="submit", loader="true", text="Submit Donation", iconName="eye-off") }}
+
+        <h3 class="spirit-h5">Submit - input type button - Icon Right</h3>
+        {{ library.button(el="button", type="submit", loader="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Submit - input type button - Icon Only</h3>
+        {{ library.button(el="button", type="submit", loader="true", iconName="eye-off", iconPosition="right", buttonTitle="Submit Donation") }}
+
+        <h2 class="spirit-h4">Loading / Submit Buttons with Icons</h2>
+
+        <h3 class="spirit-h5">Normal Loader</h3>
+
+        {{ library.button(loader="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Sumbit Loader</h3>
+        {{ library.button(tag="button", el="submit", loader="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Loader Loading</h3>
+        {{ library.button(class="spirit-button--loading", loader="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Submit Loader Loading</h3>
+        {{ library.button(class="spirit-button--loading", el="button", type="submit", loader="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Success with Loader</h3>
+        {{ library.button(loader="true", feedbackType="true", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Success no Loader</h3>
+        {{ library.button(feedbackType="success", text="Submit Donation", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Success - with Loader and Success Text</h3>
+        {{ library.button(loader="true", feedbackType="success", text="Submit Donation", feedbackText="Success", iconName="eye-off", iconPosition="right") }}
+
+        <h3 class="spirit-h5">Success - no Loader and Success Text</h3>
+        {{ library.button(feedbackType="success", text="Submit Donation", feedbackText="Success", iconName="eye-off", iconPosition="right") }}
+
+        <h2 class="spirit-h4">Button with only icon as text output - sizes</h2>
+        <p>
+            {{ library.button(class="spirit-button--success spirit-button--extra-small", iconName="check", iconLabel="Success") }}
+        </p>
+
+        <p>
+            {{ library.button(class="spirit-button--success spirit-button--small", iconName="check", iconLabel="Success") }}
+        </p>
+
+
+        <p>
+            {{ library.button(class="spirit-button--success", iconName="check", iconLabel="Success") }}
+        </p>
+
+
+        <p>
+            {{ library.button(class="spirit-button--success spirit-button--large", iconName="check", iconLabel="Success") }}
+        </p>
+
+                
     {% endset %}
 
     {% call library.container(padding_bottom="none") %}

--- a/library/docs/sink-pages/components/button-icons.njk
+++ b/library/docs/sink-pages/components/button-icons.njk
@@ -22,33 +22,6 @@
 
     {% set sample_icon_buttons %}
 
-        <div class="spirit-long-form-text">
-            <p>This sink page is to test new styles / updates for buttons with icons and resiliency.</p>
-            <h3 class="spirit-h6">Current issues questions to be resolved:</h3>
-            <ul>
-                <li><b>Note</b>: There is no 'upload' icon in library. Do we need to add?</li>
-                <li><b>Side note</b>: spirit heading classes ignored in long form text - like `spirit-h6`. May want to add ticket in backlog?</li>
-                <li>Removed `.spirit-button--has-icon` and `spirit-button__inner--has-icon` styles as now inherited directly from `spirit-button`</li>
-                <li>Removed explicit instances of `.spirit-icon` styles (sizing) as not inherited from `spirit-button`</li>
-                <li><b>Engineering decision</b>: to use span around 'text' or 'label' on all buttons?
-                    <ul>
-                        <li>Chose no inner span for 'text' as to maintain current markup as much as possible and avoid any potential 'breaking changes.'</li>
-                        <li>Potential issue with no span for text: centered text when text wraps. See below.</li>
-                    </ul>
-                </li>
-                <li>Buttons with only icon as text (like submit button - not round), set icon to same size as new update (was smaller). Need confirmation. </li>
-                <li>Button groups on dark - border not visible. Should update here? </li>
-                <li>Updated toggle buttons sink to use different IDs </li>
-            </ul>
-            <h3 class="spirit-h6">Some desgin system reference links:</h3>
-            <ul>
-                <li><a href="https://www.lightningdesignsystem.com/components/buttons/">Salesforce</a></li>
-                <li><a href="https://opensource.adobe.com/spectrum-css/components/button-primary/">Adobe</a></li>
-                <li><a href="https://material.io/components/buttons/#">Material</a></li>
-                <li><a href="https://rei.github.io/rei-cedar-docs/components/buttons/">Cedar</a></li>
-            </ul>
-        </div>
-
         <h2 class="spirit-h4">Primary</h2>
 
         <h3 class="spirit-h5">Large</h3>

--- a/library/docs/sink-pages/components/button-icons.njk
+++ b/library/docs/sink-pages/components/button-icons.njk
@@ -1,0 +1,86 @@
+{% extends "templates/sink.njk" %}
+{% block body %}
+    {% call library.container(padding_bottom="none") %}
+        {% filter markdown(true, "hostile-sink-reset") %}
+            # Buttons Icons Sink
+        {% endfilter %}
+    {% endcall %}
+
+    {% set sample_icon_buttons %}
+        <h1 class="spirit-h4">Primary</h1>
+
+        <h2 class="spirit-h5">Large</h2>
+        <p>{{ library.button(class="spirit-button--large", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Large with Icon Left</h2>
+        <p>{{ library.button(class="spirit-button--large", text="Donate Today", iconName="camera") }}</p>
+
+        <h2 class="spirit-h5">Medium (Default)</h2>
+        <p>{{ library.button(text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Medium (Default) with Icon Left</h2>
+        <p>{{ library.button(text="Donate Today", iconName="camera") }}</p>
+
+
+        <h2 class="spirit-h5">Variants MAY NEED INNER CONTAINER - INLINE FLEX BLOCK</h2>
+        <div class="spirit-long-form-text">
+        <p>Some links to compare - to have an inner div or not?</p>
+            <ul>
+            
+                <li><a href="https://www.lightningdesignsystem.com/components/buttons/">Salesforce</a></li>
+                <li><a href="https://developer.microsoft.com/en-us/fabric#/components/button">Fabric</a></li>
+                <li><a href="https://opensource.adobe.com/spectrum-css/components/button-primary/">Adobe</a></li>
+                <li><a href="https://material.io/components/buttons/#">Material</a></li>
+                <li><a href="https://rei.github.io/rei-cedar-docs/components/buttons/">Cedar</a></li>
+            </ul>
+        </div>
+
+
+        <p>{{ library.button(el="checkbox", text="Donate Today", iconName="camera") }}</p>
+        <p>{{ library.button(el="radio", text="Donate Today", iconName="camera") }}</p>
+        <p>{{ library.button(el="a", href="#", text="Donate Today", iconName="camera") }}</p>
+
+        <h2 class="spirit-h5">Medium (Default) with Icon Right</h2>
+        <p>{{ library.button(text="Donate Today", iconName="camera") }}</p>
+
+        <p>Should the next button be the same icon size as above or remain as `$spirit-size-icon-s`?</p>
+        {{ library.button(loader="true", feedbackType="true", text="Submit Donation") }}
+
+        {{ library.button(class="spirit-button--icon-only", iconName="chevron-right") }}
+
+         <h2 class="spirit-h5">Small</h2>
+        <p>{{ library.button(class="spirit-button--small", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Extra Small</h2>
+        <p>{{ library.button(class="spirit-button--extra-small", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Full Width</h2>
+        <p>{{ library.button(text="Donate Today", fullwidth="true") }}</p>
+
+        <h2 class="spirit-h5">Default to Large LG Breakpoint</h2>
+        <p>{{ library.button(class="spirit-button--large-lg", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Default to Large MD Breakpoint</h2>
+        <p>{{ library.button(class="spirit-button--large-md", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Small to Default LG Breakpoint</h2>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-lg", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Small to Default MD Breakpoint</h2>
+        <p>{{ library.button(class="spirit-button--small spirit-button--default-md", text="Donate Today") }}</p>
+
+        <h2 class="spirit-h5">Extra Small to Small MD Breakpoint to Default LG Breakpoint</h2>
+        <p>{{ library.button(class="spirit-button--extra-small spirit-button--small-md spirit-button--default-lg", text="Donate Today") }}</p>
+    {% endset %}
+
+    {% call library.container(padding_bottom="none") %}
+        <div class="spirit-row">
+            <div class="spirit-col-md">
+                {{ sample_icon_buttons | safe }}
+            </div>
+            <div class="spirit-col-md spirit-context--brand">
+                {{ sample_icon_buttons | safe }}
+            </div>
+        </div>
+    {% endcall %}
+{% endblock body %}

--- a/library/docs/sink-pages/components/button-icons.njk
+++ b/library/docs/sink-pages/components/button-icons.njk
@@ -259,150 +259,6 @@
         <h3 class="spirit-h5">Icon Only Large</h3>
         {{ library.button(class="spirit-button--minimal spirit-button--icon-only spirit-button--large", iconName="eye-off") }}
 
-        <h2 class="spirit-h4">Button Groups</h2>
-
-        <h3 class="spirit-h5">Button Groups Extra Small</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10") }}
-            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}
-            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Extra Small Icon Left</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10", iconName="camera") }}
-            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15", iconName="camera") }}
-            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20", iconName="camera") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Extra Small Icon Right</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20", iconName="camera", iconPosition="right") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Extra Small Icon Only</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option12", value="10", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option13", value="15", iconName="camera", buttonTitle="$15") }}
-            {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option14", value="20", iconName="camera", buttonTitle="$20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Small</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10") }}
-            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15") }}
-            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Small Icon Left</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10", iconName="camera") }}
-            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15", iconName="camera") }}
-            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20", iconName="camera") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Small Icon Right</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22", value="10", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23", value="15", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24", value="20", iconName="camera", iconPosition="right") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Small Icon Only</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option22", value="10", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option23", value="15", iconName="camera", buttonTitle="$15") }}
-            {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option24", value="20", iconName="camera", buttonTitle="$20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Standard / Default</h3>
-        {% call library.button_group() %}
-            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10") }}
-            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15") }}
-            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Standard / Default Icon Left</h3>
-        {% call library.button_group() %}
-            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10", iconName="camera") }}
-            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15", iconName="camera") }}
-            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20", iconName="camera") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Standard / Default Icon Right</h3>
-        {% call library.button_group() %}
-            {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="10", iconName="camera", iconPosition="right") }}
-            {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="15", iconName="camera", iconPosition="right") }}
-            {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="20", iconName="camera", iconPosition="right") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Standard / Default Icon Only</h3>
-        {% call library.button_group() %}
-            {{ library.button(el="radio", name="radio-group", id="option32", value="10", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(el="radio", name="radio-group", id="option33", value="15", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(el="radio", name="radio-group", id="option34", value="20", iconName="camera", buttonTitle="$10") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Large</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10") }}
-            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15") }}
-            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Large Icon Left</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10", iconName="camera") }}
-            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15", iconName="camera") }}
-            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20", iconName="camera") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Large Icon Right</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42", value="10", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43", value="15", iconName="camera", iconPosition="right") }}
-            {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44", value="20", iconName="camera", iconPosition="right") }}
-        {% endcall %}
-
-        <h3 class="spirit-h5">Button Groups Large Icon Only</h3>
-        {% call library.button_group() %}
-            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option42", value="10", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option43", value="15", iconName="camera", buttonTitle="$10") }}
-            {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option44", value="20", iconName="camera", buttonTitle="$10") }}
-        {% endcall %}
-
-        <h2 class="spirit-h4">Toggle Groups</h2>
-
-        <h3 class="spirit-h5">Default</h3>
-
-        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250") }}
-        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120") }}
-        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60") }}
-        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30") }}
-
-        <h3 class="spirit-h5">Default Icon Left</h3>
-
-        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera") }}
-        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera") }}
-        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera") }}
-        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera") }}
-
-        <h3 class="spirit-h5">Default Icon Right</h3>
-
-        {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera", iconPosition="right") }}
-        {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera", iconPosition="right") }}
-        {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera", iconPosition="right") }}
-        {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera", iconPosition="right") }}
-
-        <h3 class="spirit-h5">Default Icon Only</h3>
-
-        {{ library.button(el="radio", name="radiogroup", id="radio-option1", value="250", iconName="camera", buttonTitle="$250") }}
-        {{ library.button(el="radio", name="radiogroup", id="radio-option2", value="120", iconName="camera", buttonTitle="$120") }}
-        {{ library.button(el="radio", name="radiogroup", id="radio-option3", value="60", iconName="camera", buttonTitle="$60") }}
-        {{ library.button(el="radio", name="radiogroup", id="radio-option4", value="30", iconName="camera", buttonTitle="$30") }}
-
         <h2 class="spirit-h4">Additional Testing Variants</h2>
 
         <h3 class="spirit-h5">Submit Icon Only</h3>
@@ -466,17 +322,302 @@
         <p>
             {{ library.button(class="spirit-button--success spirit-button--large", iconName="check", iconLabel="Success") }}
         </p>
-
-                
     {% endset %}
 
-    {% call library.container(padding_bottom="none") %}
+    {% call library.container(padding_top="none") %}
         <div class="spirit-row">
             <div class="spirit-col-md">
                 {{ sample_icon_buttons | safe }}
+                <h2 class="spirit-h4">Button Groups</h2>
+
+                <h3 class="spirit-h5">Button Groups Extra Small</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option12", value="10") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option13", value="15") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option14", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option15", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option16", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option17", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option18", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option19", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option20", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option21", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option22", value="15", iconName="camera", buttonTitle="$15") }}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option23", value="20", iconName="camera", buttonTitle="$20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option221", value="10") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option231", value="15") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option241", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option222", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option232", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option242", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option223", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option233", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option243", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option22", value="104", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option23", value="154", iconName="camera", buttonTitle="$15") }}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option24", value="204", iconName="camera", buttonTitle="$20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option325", value="10") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option335", value="15") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option345", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="106", iconName="camera") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="156", iconName="camera") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="206", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option32", value="107", iconName="camera", iconPosition="right") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option33", value="157", iconName="camera", iconPosition="right") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option34", value="207", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(el="radio", name="radio-group", id="option328", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(el="radio", name="radio-group", id="option338", value="15", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(el="radio", name="radio-group", id="option348", value="20", iconName="camera", buttonTitle="$10") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option429", value="10") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option439", value="15") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option449", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option4211", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option4311", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option4411", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option4222", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option4322", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option4422", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option4233", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option4333", value="15", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option4433", value="20", iconName="camera", buttonTitle="$10") }}
+                {% endcall %}
+
+                <h2 class="spirit-h4">Toggle Groups</h2>
+
+                <h3 class="spirit-h5">Default</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option11", value="250") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option21", value="120") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option31", value="60") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option41", value="30") }}
+
+                <h3 class="spirit-h5">Default Icon Left</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option12", value="250", iconName="camera") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option22", value="120", iconName="camera") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option32", value="60", iconName="camera") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option42", value="30", iconName="camera") }}
+
+                <h3 class="spirit-h5">Default Icon Right</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option13", value="250", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option23", value="120", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option33", value="60", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option43", value="30", iconName="camera", iconPosition="right") }}
+
+                <h3 class="spirit-h5">Default Icon Only</h3>
+
+                {{ library.button(el="radio", name="radiogroup", id="radio-option14", value="250", iconName="camera", buttonTitle="$250") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option24", value="120", iconName="camera", buttonTitle="$120") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option34", value="60", iconName="camera", buttonTitle="$60") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option44", value="30", iconName="camera", buttonTitle="$30") }}
             </div>
             <div class="spirit-col-md spirit-context--brand">
                 {{ sample_icon_buttons | safe }}
+
+                <h2 class="spirit-h4">Button Groups</h2>
+
+                <h3 class="spirit-h5">Button Groups Extra Small</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option1255", value="10") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option1355", value="15") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option1455", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option1266", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option1366", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option1466", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", text="$10", el="radio", name="radio-group", id="option1277", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$20", el="radio", name="radio-group", id="option1377", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--extra-small", text="$30", el="radio", name="radio-group", id="option1477", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Extra Small Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option1288", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option1388", value="15", iconName="camera", buttonTitle="$15") }}
+                    {{ library.button(class="spirit-button--extra-small", el="radio", name="radio-group", id="option1488", value="20", iconName="camera", buttonTitle="$20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option2299", value="10") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option2399", value="15") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option2499", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option2200", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option2300", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option2400", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", text="$10", el="radio", name="radio-group", id="option22111", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--small", text="$20", el="radio", name="radio-group", id="option23111", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--small", text="$30", el="radio", name="radio-group", id="option24111", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Small Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option22222", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option23222", value="15", iconName="camera", buttonTitle="$15") }}
+                    {{ library.button(class="spirit-button--small", el="radio", name="radio-group", id="option24222", value="20", iconName="camera", buttonTitle="$20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option32333", value="10") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option33333", value="15") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option34333", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option32444", value="10", iconName="camera") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option33444", value="15", iconName="camera") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option34444", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(text="$10", el="radio", name="radio-group", id="option32555", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(text="$20", el="radio", name="radio-group", id="option33555", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(text="$30", el="radio", name="radio-group", id="option34555", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Standard / Default Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(el="radio", name="radio-group", id="option32666", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(el="radio", name="radio-group", id="option33666", value="15", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(el="radio", name="radio-group", id="option34666", value="20", iconName="camera", buttonTitle="$10") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42777", value="10") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43777", value="15") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44777", value="20") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Left</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42888", value="10", iconName="camera") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43888", value="15", iconName="camera") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44888", value="20", iconName="camera") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Right</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", text="$10", el="radio", name="radio-group", id="option42999", value="10", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--large", text="$20", el="radio", name="radio-group", id="option43999", value="15", iconName="camera", iconPosition="right") }}
+                    {{ library.button(class="spirit-button--large", text="$30", el="radio", name="radio-group", id="option44999", value="20", iconName="camera", iconPosition="right") }}
+                {% endcall %}
+
+                <h3 class="spirit-h5">Button Groups Large Icon Only</h3>
+                {% call library.button_group() %}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option42000", value="10", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option43000", value="15", iconName="camera", buttonTitle="$10") }}
+                    {{ library.button(class="spirit-button--large", el="radio", name="radio-group", id="option44000", value="20", iconName="camera", buttonTitle="$10") }}
+                {% endcall %}
+
+                <h2 class="spirit-h4">Toggle Groups</h2>
+
+                <h3 class="spirit-h5">Default</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option111", value="250") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option211", value="120") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option311", value="60") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option411", value="30") }}
+
+                <h3 class="spirit-h5">Default Icon Left</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option122", value="250", iconName="camera") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option222", value="120", iconName="camera") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option322", value="60", iconName="camera") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option422", value="30", iconName="camera") }}
+
+                <h3 class="spirit-h5">Default Icon Right</h3>
+
+                {{ library.button(text="$250", el="radio", name="radiogroup", id="radio-option133", value="250", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$120", el="radio", name="radiogroup", id="radio-option233", value="120", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$60", el="radio", name="radiogroup", id="radio-option333", value="60", iconName="camera", iconPosition="right") }}
+                {{ library.button(text="$30", el="radio", name="radiogroup", id="radio-option433", value="30", iconName="camera", iconPosition="right") }}
+
+                <h3 class="spirit-h5">Default Icon Only</h3>
+
+                {{ library.button(el="radio", name="radiogroup", id="radio-option144", value="250", iconName="camera", buttonTitle="$250") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option244", value="120", iconName="camera", buttonTitle="$120") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option344", value="60", iconName="camera", buttonTitle="$60") }}
+                {{ library.button(el="radio", name="radiogroup", id="radio-option444", value="30", iconName="camera", buttonTitle="$30") }}
             </div>
         </div>
     {% endcall %}

--- a/library/docs/sink-pages/components/buttons.njk
+++ b/library/docs/sink-pages/components/buttons.njk
@@ -451,9 +451,24 @@
                 {% endfilter %}
 
                 {% filter markdown(true, "hostile-sink-reset") %}
+                    ## Extra Small
+                {% endfilter %}
+                {{ library.button(class="spirit-button--icon-only spirit-button--extra-small", iconName="chevron-right") }}
+
+                {% filter markdown(true, "hostile-sink-reset") %}
                     ### Small
                 {% endfilter %}
                 {{ library.button(class="spirit-button--icon-only spirit-button--small", iconName="chevron-right") }}
+
+                {% filter markdown(true, "hostile-sink-reset") %}
+                    ## Medium
+                {% endfilter %}
+                {{ library.button(class="spirit-button--icon-only ", iconName="chevron-right") }}
+
+                {% filter markdown(true, "hostile-sink-reset") %}
+                    ## Large
+                {% endfilter %}
+                {{ library.button(class="spirit-button--icon-only spirit-button--large", iconName="chevron-right") }}
 
                 {% filter markdown(true, "hostile-sink-reset") %}
                     ### Small to Default MD

--- a/library/docs/sink-pages/components/buttons.njk
+++ b/library/docs/sink-pages/components/buttons.njk
@@ -4,8 +4,21 @@
     {% filter markdown(true, "hostile-sink-reset") %}
         # Buttons Sink
     {% endfilter %}
+    {% call library.container(padding_bottom="none") %}
+        <div class="spirit-long-form-text">
+            <p>Related Sink Pages:</p>
+            <ul>
+                <li>
+                    <a href="/sink-pages/components/button-groups.html">Button Groups</a>
+                </li>
+                <li>
+                    <a href="/sink-pages/components/button-icons.html">Icon Buttons</a>
+                </li>
+            </ul>
+        </div>
+    {% endcall %}
     <div class="spirit-container">
-        <div class="spirit-container__inner">
+        <div class="spirit-container__inner spirit-container__inner--padding-top-none">
         <div class="spirit-row">
             <div class="spirit-col spirit-col-md-6 spirit-col-lg-4">
 


### PR DESCRIPTION
This MR adds the following updates for icon button enhancements:
- add icon button sink
- update icon sizes, styles
- update njk button markup output + parameter options
- remove some 'spirit-icon' styles in button as can now inherit primary 'spirit-button' styles
- use common icon sizes in buttons
- add class / style for spirit-icon left and right
- Chose NOT to use a span around the label / button text by default to maintain current markup as much as possible. ISSUE - when text wraps, it is centered.
- Buttons with only icon (i.e. success) - changed icon size to match icon sizes used in designs for different button types (made larger)

Additional updates included:
- fix button groups sink repeating component ids
- add button group z-index when in use to allow border to show

Notes / Questions:
- Spirit Heading Classes in Long Form Text: spirit heading classes (i.e. `spirit-h4`) are ignored in `.spirit-long-form-text`. Should this be updated? New ticket?

To review:
1. Pull branch
2. in `/library` run `grunt`
3. Visit `/sink-pages/components/button-icons.html` and review
4. Visit `/sink-pages/components/buttons.html` and review
5. Visit `/sink-pages/components/button-groups.html` and review