### PR TITLE
Feature/dgst 81 input icon collision update

### DIFF
--- a/library/components/button/button.njk
+++ b/library/components/button/button.njk
@@ -110,7 +110,7 @@
       {% if href %}
         href="{{href}}"
       {% endif %}
-      class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--is-icon' if icon and not text}}"
+      class="spirit-button{{ ' ' + class if class }}{{ ' spirit-button--fullwidth' if fullwidth }}{{ ' spirit-button--is-icon' if iconName and not text}}"
       {% if loader %}
         data-loader="{{loader}}"
       {% endif %}
@@ -175,6 +175,7 @@
             {{ displayIcon | safe }}
           {% endif %}
           {{ text if text }}
+          {{ caller() if caller }}
           {% if displayIcon and iconPosition === "right" %}
             {{ displayIcon | safe }}
           {% endif %}
@@ -184,9 +185,12 @@
           {{ displayIcon | safe }}
         {% endif %}
         {{ text if text }}
+        {{ caller() if caller }}
         {% if displayIcon and iconPosition === "right" %}
           {{ displayIcon | safe }}
         {% endif %}
+      {% else %}
+        {{ caller() if caller }}
       {% endif %}
     </{{el}}>
   {% endif %}

--- a/library/components/form/form.js
+++ b/library/components/form/form.js
@@ -16,24 +16,40 @@ class SpiritFormPasswordToggle {
     const passwordToggleInputs = Array.from(document.querySelectorAll('.spirit-form__input--password-toggle'));
     passwordToggleInputs.forEach(i => {
       const input = i.querySelector('input');
-      const trigger = i.querySelector('a');
+      const trigger = i.querySelector('.spirit-form__input-password-toggle');
+      const triggerIconHide = trigger.querySelector('svg[aria-label="Hide"]');
+      const triggerIconShow = trigger.querySelector('svg[aria-label="Show"]');
 
-      if (trigger.innerText === 'Show') {
+      // A11y Setup
+      if (triggerIconHide.getAttribute("aria-hidden") === 'true') {
         trigger.setAttribute('aria-pressed', 'false');
       } else {
         trigger.setAttribute('aria-pressed', 'true');
       }
 
+      // On input focus
+      input.addEventListener('focus', () => {
+        i.classList.toggle('spirit-form__input--password-toggle--focus');
+      });
+
+      // In input blur
+      input.addEventListener('blur', () => {
+        i.classList.toggle('spirit-form__input--password-toggle--focus');
+      });
+
+      // On toggle show password click
       trigger.addEventListener('click', e => {
         e.preventDefault();
         if (input.type === 'text') {
           input.type = 'password';
-          trigger.textContent = 'Show';
           trigger.setAttribute('aria-pressed', 'false');
+          triggerIconHide.setAttribute('aria-hidden', 'false');
+          triggerIconShow.setAttribute('aria-hidden', 'true');
         } else {
           input.type = 'text';
-          trigger.textContent = 'Hide';
           trigger.setAttribute('aria-pressed', 'true');
+          triggerIconHide.setAttribute('aria-hidden', 'true');
+          triggerIconShow.setAttribute('aria-hidden', 'false');
         }
       });
     });

--- a/library/components/form/form.njk
+++ b/library/components/form/form.njk
@@ -52,7 +52,9 @@
             inputmode=false,
             valid,
             password_toggle=false,
-            password_toggle_visible=false) %}
+            password_toggle_visible=false
+        )
+    %}
 
     {# Set a modifier class based on the valid argument #}
     {% if valid == true %}
@@ -110,11 +112,16 @@
         {% endif %}
         {% if password_toggle %}
             {% if password_toggle_visible %}
-                {% set password_toggle_text = "Hide" %}
+                {% call button(class="spirit-form__input-password-toggle spirit-button--icon-only spirit-button--extra-small spirit-button--is-icon spirit-button--minimal", buttonTitle="toggle password visibility") %}
+                    {{ icon(name="eye", class="spirit-icon--input-helper", decorative=false, label="Show" )}}
+                    {{ icon(name="eye-off", class="spirit-icon--input-helper", decorative=true, label="Hide" )}}
+                {% endcall %}
             {% else %}
-                {% set password_toggle_text = "Show" %}
+                {% call button(class="spirit-form__input-password-toggle spirit-button--icon-only spirit-button--extra-small spirit-button--is-icon spirit-button--minimal", buttonTitle="toggle password visibility") %}
+                    {{ icon(name="eye", class="spirit-icon--input-helper", decorative=true, label="Show" )}}
+                    {{ icon(name="eye-off", class="spirit-icon--input-helper", decorative=false, label="Hide" )}}
+                {% endcall %}
             {% endif %}
-          {{ link(class="spirit-form__input-password-toggle", text=password_toggle_text, role="button") }}
         {% endif %}
     </div>
 {% endmacro %}

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -1027,10 +1027,11 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
 .spirit-form__input-password-toggle {
   @include spirit-typography-reset($color: $spirit-text-color-link, $font-weight: $spirit-font-weight-bold);
   cursor: pointer;
+  flex: 1 0 $spirit-form-element-height;
   height: $spirit-form-element-height;
+  max-width: $spirit-form-element-height;
   position: static;
   text-decoration: none;
-  width: $spirit-form-element-height;
   z-index: 20; // insure above password helper image
 
   .spirit-icon {

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -52,6 +52,23 @@ $spirit-form-element-grid-space:            0 $spirit-space-generic-2-x $spirit-
 
 $spirit-form-input-password-toggle-padding: 70px;
 
+@mixin input-styles {
+  @include spirit-box-sizing;
+  @include spirit-typography-reset(
+    $color: $spirit-text-input-color,
+    $font-size: $spirit-text-input-font-size,
+    $font-weight: $spirit-font-weight-regular
+  );
+  background-color: $spirit-text-input-background-color;
+  border: $spirit-text-input-border;
+  border-radius: $spirit-form-element-border-radius;
+  display: block;
+  margin: 0;
+  max-width: $spirit-text-input-max-width;
+  min-height: 48px; // Needed for IE11
+  width: 100%;
+}
+
 @mixin invalid-styles {
   border-color: $spirit-form-element-border-color-error;
 }
@@ -74,6 +91,7 @@ $spirit-form-input-password-toggle-padding: 70px;
   border: solid $spirit-form-element-border-width $spirit-form-element-focus-color;
   outline: none;
 }
+
 // ********************** End shared form variables
 
 // Form
@@ -181,21 +199,8 @@ $spirit-text-input-padding:           $spirit-form-element-padding;
 }
 
 .spirit-form__input-field {
-  @include spirit-box-sizing;
-  @include spirit-typography-reset(
-    $color: $spirit-text-input-color,
-    $font-size: $spirit-text-input-font-size,
-    $font-weight: $spirit-font-weight-regular
-  );
-  background-color: $spirit-text-input-background-color;
-  border: $spirit-text-input-border;
-  border-radius: $spirit-form-element-border-radius;
-  display: block;
-  margin: 0;
-  max-width: $spirit-text-input-max-width;
-  min-height: 48px; // Needed for IE11
+  @include input-styles;
   padding: $spirit-text-input-padding;
-  width: 100%;
 
   &::placeholder {
     @include spirit-typography-reset(
@@ -988,19 +993,56 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
 }
 
 .spirit-form__input--password-toggle {
+  @include spirit-box-sizing;
+  @include spirit-typography-reset;
+  background-color: transparent;
+  display: flex;
+  flex-flow: row nowrap;
   position: relative;
 
+  &:after {
+    @include input-styles;
+    content: '';
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: -1;
+  }
+
   .spirit-form__input-field {
-    padding-right: $spirit-form-input-password-toggle-padding; // Push content away from "Show/Hide" toggle
+    background-color: transparent;
+    border-width: 0;
+  }
+}
+
+.spirit-form__input--password-toggle--focus {
+  &:after {
+    @include focus-styles;
+    height: 100%;
   }
 }
 
 .spirit-form__input-password-toggle {
   @include spirit-typography-reset($color: $spirit-text-color-link, $font-weight: $spirit-font-weight-bold);
   cursor: pointer;
-  position: absolute;
-  right: $spirit-space-generic-2-x;
+  height: 48px;
+  position: static;
   text-decoration: none;
-  top: 50%;
-  transform: translateY(-50%);
+  width: 48px;
+  z-index: 20; // insure above password helper image
+
+  .spirit-icon {
+    pointer-events: none;
+
+    &[aria-hidden='true'] {
+      display: none;
+    }
+  }
+}
+
+// Disable Styles for LastPass form helpers
+div[id^=__lpform_] {
+  display: none !important; // sass-lint:disable-line no-important - have to target LassPass styles directly
 }

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -1027,10 +1027,10 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
 .spirit-form__input-password-toggle {
   @include spirit-typography-reset($color: $spirit-text-color-link, $font-weight: $spirit-font-weight-bold);
   cursor: pointer;
-  height: 48px;
+  height: $spirit-form-element-height;
   position: static;
   text-decoration: none;
-  width: 48px;
+  width: $spirit-form-element-height;
   z-index: 20; // insure above password helper image
 
   .spirit-icon {

--- a/library/components/link/link.njk
+++ b/library/components/link/link.njk
@@ -4,6 +4,7 @@
   href=false,
   target=false,
   type=false,
+  label=false,
   role
 ) %}
   <a 
@@ -11,7 +12,8 @@
     {% if href %} href="{{ href }}" {% endif %}
     {% if type %} type="{{ type }}" {% endif %}
     {% if target %} target="{{ target }}" {% endif %}
-    {% if role %} role="{{ role }}" {% endif %}>
+    {% if role %} role="{{ role }}" {% endif %}
+    {% if label %} aria-label="{{ label }}" {% endif %}>
       {{text if text}}
       {{ caller() if caller }}
     </a>

--- a/library/docs/sink-pages/components/password-input-with-toggle.njk
+++ b/library/docs/sink-pages/components/password-input-with-toggle.njk
@@ -27,5 +27,43 @@
     <h2 class="hostile-sink-reset">Content Resilience</h2>
     {{ library.form_input(type="password", password_toggle=true, value="A really really long password that you'll laugh at when you toggle it to visible cause it's so funny LOLOLOLOLOLOLOLOLOLOLOLOLOL") }}
 
+    <h2 class="hostile-sink-reset">Inside fieldset</h2>
+    {% call library.form() %}
+      {% call library.form_fieldset() %}
+          {{ library.form_legend(text="Contact Info", hidden=true) }}
+          <div class="spirit-row">
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="First Name", for="contact-info-first-name") }}
+                  {{ library.form_input(id="contact-info-first-name") }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="Last Name", for="contact-info-last-name") }}
+                  {{ library.form_input(id="contact-info-last-name") }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="Password", for="contact-info-password") }}
+                  {{ library.form_input(id="contact-info-password", type="password", password_toggle=true, value="password") }}
+                {% endcall %}
+              </div>
+              <div class="spirit-col-md-6">
+                {% call library.form_field_group() %}
+                  {{ library.form_label(text="Password Verify", for="contact-info-password-verify") }}
+                  {{ library.form_input(id="contact-info-password-verify", type="password", password_toggle=true, value="password") }}
+                {% endcall %}
+              </div>
+          </div>
+
+          {% call library.form_field_group() %}
+              {{ library.form_label(text="Email", for="contact-info-email") }}
+              {{ library.form_input(id="contact-info-email") }}
+          {% endcall %}
+      {% endcall %}
+    {% endcall %}
+
   </div> {# closing div.forms-sink-wrapper #}
 {% endblock body %}


### PR DESCRIPTION
**NOTE**: this is a breaking change if in use. Should be part of major release, original component so new it is not a concern?

- use icon button instead of `<a>`
- update styles to container to match a spirit input
- update scripts to toggle inputs / container
- update sink page
- add caller ability to button njk file
- add ability to add aria-label to link
- using scripts to generate focus styles - not input itself

To test:
1. Pull branch
2. In `library` run `gulp`
3. Review `/sink-pages/components/password-input-with-toggle.html`
