### PR TITLE
Remove min height for all dialogs

### DIFF
--- a/library/components/dialog/dialog.scss
+++ b/library/components/dialog/dialog.scss
@@ -12,8 +12,6 @@ $spirit-dialog-viewport-max-height: calc(100% - #{$spirit-space-generic-4-x}); /
 $spirit-dialog-viewport-max-height-med: calc(100% - (#{$spirit-dialog-top-med} * 2)); // To enable dialot do display properly in iOS with safari navbar open or closed
 $spirit-dialog-max-height: calc(100vh - #{$spirit-space-generic-4-x});
 $spirit-dialog-max-height-med: calc(100vh - (#{$spirit-dialog-top-med} * 2));
-$spirit-dialog-min-height: 300px;
-$spirit-dialog-alert-min-height: 170px;
 $spirit-dialog-content-padding: $spirit-space-inset-2-x;
 $spirit-dialog-content-padding-md: $spirit-space-inset-3-x;
 $spirit-dialog-content-padding-lg: $spirit-space-inset-4-x;
@@ -167,12 +165,10 @@ $spirit-dialog-transition-duration-short: 75ms;
   // The initial styles for .spirit-dialog__content were moved here
   // The .spirit-dialog__content was given flex-flow: row-nowrap; to contain the content
   max-width: $spirit-dialog-max-width;
-  min-height: $spirit-dialog-min-height;
 }
 
 // Alert Dialog
 .spirit-dialog__content--alert {
-  min-height: $spirit-dialog-alert-min-height;
 
   .spirit-dialog__header {
     @include spirit-elevation(0);

--- a/library/docs/sink-pages/components/dialogs.njk
+++ b/library/docs/sink-pages/components/dialogs.njk
@@ -333,7 +333,10 @@
             <h6>S Dialog Blank</h6>
             {{ library.button(class="spirit-button--extra-small", text="Open Dialog", dialog_id=dialog_id) }}
         </div>
-        {{ library.dialog(dialog_id=dialog_id) }}
+        {% call library.dialog(dialog_id=dialog_id) %}
+            {% call library.dialog_content() %}
+            {% endcall %}
+        {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple-s" %}
         <div class="spirit-long-form-text">
@@ -342,6 +345,8 @@
         </div>
         {% call library.dialog(dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Simple", dialog_id=dialog_id) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple--overlay-s" %}
@@ -351,6 +356,8 @@
         </div>
         {% call library.dialog(overlay_opacity="dark", dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Dark Overlay", dialog_id=dialog_id) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple-title-s" %}
@@ -360,6 +367,8 @@
         </div>
         {% call library.dialog(dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Edit Story Oops Title is Accidentally Way Too Long To Fit in the Header", dialog_id=dialog_id) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple-mult-s" %}
@@ -369,6 +378,8 @@
         </div>
         {% call library.dialog(dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Multiple Actions", dialog_id=dialog_id, header_icons=[{ iconName: "search", buttonTitle: "Search" }, { iconName: "more-horizontal", buttonTitle: "More"}]) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple-mult-title-s" %}
@@ -378,6 +389,8 @@
         </div>
         {% call library.dialog(dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Edit Story Oops Title is Accidentally Way Too Long To Fit in the Header", dialog_id=dialog_id, header_icons=[{ iconName: "search", buttonTitle: "Search" }, { iconName: "more-horizontal", buttonTitle: "More"}]) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-simple-foot-s" %}
@@ -562,7 +575,10 @@
             <h6>M Dialog Blank</h6>
             {{ library.button(class="spirit-button--extra-small", text="Open Dialog", dialog_id=dialog_id) }}
         </div>
-        {{ library.dialog(size="medium", dialog_id=dialog_id) }}
+        {% call library.dialog(size="medium", dialog_id=dialog_id) %}
+          {% call library.dialog_content() %}
+          {% endcall %}
+        {% endcall %}
 
         {% set dialog_id = "dialog-demo-m" %}
         <div class="spirit-long-form-text">
@@ -571,6 +587,8 @@
         </div>
         {% call library.dialog(size="medium", dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Simple", dialog_id=dialog_id) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-foot-m" %}
@@ -662,7 +680,10 @@
             <h6>L Dialog Blank</h6>
             {{ library.button(class="spirit-button--extra-small", text="Open Dialog", dialog_id=dialog_id) }}
         </div>
-        {{ library.dialog(size="large", dialog_id=dialog_id) }}
+        {% call library.dialog(size="large", dialog_id=dialog_id) %}
+          {% call library.dialog_content() %}
+          {% endcall %}
+        {% endcall %}
 
         {% set dialog_id = "dialog-demo-l" %}
         <div class="spirit-long-form-text">
@@ -671,6 +692,8 @@
         </div>
         {% call library.dialog(size="large", dialog_id=dialog_id, has_title=true, has_close=true) %}
           {{ library.dialog_header(title_text="Simple", dialog_id=dialog_id) }}
+          {% call library.dialog_content() %}
+          {% endcall %}
         {% endcall %}
 
         {% set dialog_id = "dialog-demo-foot-l" %}


### PR DESCRIPTION
- removed min-with from all dialogs

Due to the Simple dialog from having any height in the library, I've added the dialog content block to give it some height and, therefore, be viewable.

The Simple dialog already has the content block on the `doc-site` so that did not need to be changed.

To view in library:
1. pull branch
2. in `/libarary` run `gulp`

To view in doc site
1. pull branch
2. in `/doc-site` run `npm run link-local-library`
3. in `/doc-site` run `gulp`
