### PR TITLE
Add link styles to form message

### DIFF
--- a/doc-site/docs/components/feedback-messages.njk
+++ b/doc-site/docs/components/feedback-messages.njk
@@ -19,7 +19,16 @@
       Informational messages communicate non-critical information.
   {% endfilter %}
 
-  {{ esds_doc.code_example_pair(example=library.form_message(text="Only 21 seats remaining.")) }}
+  {% set feeback_information %}
+
+    {% call library.form_message(type="info") %}
+      <p>Only 21 seats remaining.</p>
+      <p>Visit <a href="#">jdrf.org</a> for more information.</p>
+    {% endcall %}
+
+  {% endset %}
+
+  {{ esds_doc.code_example_pair(example=feeback_information) }}
 
   {% filter markdown %}
       ### Success Messages

--- a/library/components/form/form.njk
+++ b/library/components/form/form.njk
@@ -488,7 +488,7 @@
 
 {% macro form_message(
     class=false,
-    text="Some information about this form",
+    text=false,
     type="info"
     ) %}
     {% set typeIcons = {
@@ -501,7 +501,9 @@
             {{ icon(name=typeIcons[type], class="spirit-form__message-icon") }}
         </div>
         <div class="spirit-form__message-text">
-            <p>{{ text | safe }}</p>
+            {% if text %}
+                <p>{{ text | safe }}</p>
+            {% endif %}
             {%- if caller -%}
                 {{ caller() }}
             {%- endif -%}

--- a/library/components/form/form.njk
+++ b/library/components/form/form.njk
@@ -501,7 +501,10 @@
             {{ icon(name=typeIcons[type], class="spirit-form__message-icon") }}
         </div>
         <div class="spirit-form__message-text">
-            {{ text | safe }}
+            <p>{{ text | safe }}</p>
+            {%- if caller -%}
+                {{ caller() }}
+            {%- endif -%}
         </div>
     </div>
 {% endmacro %}

--- a/library/components/form/form.scss
+++ b/library/components/form/form.scss
@@ -953,6 +953,34 @@ $spirit-legend-max-width:   $spirit-form-element-max-width;
   margin: $spirit-space-stack-4-x;
   padding: $spirit-space-inset-2-x;
 
+  a:not(.spirit-button) {
+    @include spirit-dark-parent-light-text;
+    color: $spirit-text-color-primary;
+    font-weight: $spirit-font-weight-bold;
+    text-decoration: underline;
+
+    &:focus {
+      outline: $spirit-border-width-input-focus solid $spirit-text-color-primary;
+    }
+
+    &:visited {
+      color: $spirit-text-color-primary;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  p {
+    margin-bottom: $spirit-space-generic-2-x;
+    margin-top: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
   &.spirit-form__message--info {
     background-color: $spirit-feedback-color-background-info;
   }

--- a/library/docs/sink-pages/components/forms.njk
+++ b/library/docs/sink-pages/components/forms.njk
@@ -652,11 +652,23 @@
 
     <h2 class="hostile-sink-reset">Form Level Messages</h2>
     {{ library.form_message(type="success", text="Success confirmation message.") }}
+    {% call library.form_message(type="success", text="Success confirmation message.") %}
+      <p>Testing a <a href="#">link</a> in form messages.</p>
+    {% endcall %}
     {{ library.form_message(type="error", text="Error highlighting message.") }}
+    {% call library.form_message(type="error", text="Error highlighting message.") %}
+      <p>Testing a <a href="#">link</a> in form messages.</p>
+    {% endcall %}
     {{ library.form_message(type="info", text="Informational message.") }}
-    
+    {% call library.form_message(type="info", text="Informational message.") %}
+      <p>Testing a <a href="#">link</a> in form messages.</p>
+    {% endcall %}
+
     <h5 class="hostile-sink-reset">Content Resilience, Long Message</h5>
     {{ library.form_message(text="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo molestias, recusandae animi quam tempora sint tenetur sapiente. Quos ipsam quidem numquam labore, repudiandae fugit, hic architecto, rem doloribus deserunt optio!") }}
+    {% call library.form_message() %}
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p><p>Explicabo molestias, recusandae animi quam tempora sint tenetur sapiente. Quos ipsam quidem numquam labore, repudiandae fugit, hic architecto, rem doloribus deserunt optio! Testing a <a href="#">link</a> in form messages.</p>
+    {% endcall %}
 
     <br>
     <br>


### PR DESCRIPTION
- add link style
- add use of paragraph tag
- add paragraph style

To test, in `/library`
- Pull branch
- Run `gulp`
- go to `/sink-pages/components/forms.html`
- See "Form Level Message"

**NOTES** 
- I noticed this component was not using a paragraph tag, so I've add it in addition to the 'link styles'. I think this should be done and also added to the documentation. Thoughts?
- The paragraph tag, if not used, will display the same
- Ideally, we remove the bottom padding of the form message as we are indicating the use of paragraphs, but, as we don't want to break anything when this is consumed, adding a 0 margin bottom to the last paragraph.
- Other items are not included in styles (i.e. lists)
- link style - black, bold, underline. Semibold is suggested, but no part of the design system. Please verify style.
- Alternative, use `spirit-long-form-text` as a wrapper class, but that creates additional new styles , so I recommend avoiding
